### PR TITLE
chore: health check tuning

### DIFF
--- a/app/log_config.py
+++ b/app/log_config.py
@@ -1,8 +1,17 @@
+import logging
 import sys
 
 from loguru import logger
 
 from app.settings import settings
+
+
+class EndpointFilter(logging.Filter):
+    def __init__(self, excluded_endpoints: list[str]):
+        self.excluded_endpoints = excluded_endpoints
+
+    def filter(self, record: logging.LogRecord):
+        return not any(ep in record.getMessage() for ep in self.excluded_endpoints)
 
 
 def _format(record):
@@ -19,8 +28,11 @@ def _format(record):
     )
 
 
-def setup_logger():
-    # Remove loguru default handler
+def setup_logging():
+    logging.getLogger("uvicorn.access").addFilter(
+        EndpointFilter(excluded_endpoints=["/health"])
+    )
+
     logger.remove()
 
     logger.add(

--- a/app/main.py
+++ b/app/main.py
@@ -14,10 +14,10 @@ from app.agent.prompts import SYSTEM_PROMPT
 from app.agent.tools import BDToolkit
 from app.api.main import api_router
 from app.db.database import engine, init_database
-from app.log_config import setup_logger
+from app.log_config import setup_logging
 from app.settings import settings
 
-setup_logger()
+setup_logging()
 
 
 @asynccontextmanager

--- a/charts/basedosdados-chatbot/templates/deployment.yaml
+++ b/charts/basedosdados-chatbot/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
               path: /health
               port: 8000
             initialDelaySeconds: 10
-            periodSeconds: 10
+            periodSeconds: 30
           readinessProbe:
             httpGet:
               path: /health


### PR DESCRIPTION
- add endpoint filtering to uvicorn access logs to filter requests to `/health` endpoint.
- increase liveness probe period to 30 seconds.