### PR TITLE
build: use uvicorn directly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,4 @@ ENV PATH="/app/.venv/bin:$PATH"
 EXPOSE 8000
 
 # Start FastAPI server
-CMD ["fastapi", "run" , "--workers", "2", "app/main.py"]
+CMD ["uvicorn", "app.main:app" , "--host", "0.0.0.0", "--workers", "2"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -34,7 +34,7 @@ services:
 
   chatbot-api:
     build: .
-    command: fastapi dev --host 0.0.0.0 app/main.py
+    command: uvicorn app.main:app --host 0.0.0.0 --reload
     env_file: .env
     environment:
       # Enable dev dependencies for local development


### PR DESCRIPTION
FastAPI CLI uses uvicorn internally, but it has some strange behaviours like wrapping up long log messages in multiple lines (probably due to using [rich](https://github.com/Textualize/rich)), which difficults observability. So, I'm starting the server using uvicorn directly.