### PR TITLE
fix: remove recursion limit config

### DIFF
--- a/app/api/routers/chatbot.py
+++ b/app/api/routers/chatbot.py
@@ -107,7 +107,6 @@ async def send_message(
 
     config = ConfigDict(
         run_id=run_id,
-        recursion_limit=32,
         configurable={"thread_id": thread_id},
     )
 

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -5,7 +5,6 @@ from pydantic import BaseModel
 
 class ConfigDict(TypedDict):
     run_id: str
-    recursion_limit: int
     configurable: dict[str, Any]
 
 

--- a/tests/app/api/test_streaming.py
+++ b/tests/app/api/test_streaming.py
@@ -326,7 +326,6 @@ class TestStreamResponse:
     def mock_config(self, mock_thread_id: str) -> ConfigDict:
         return {
             "run_id": uuid.uuid4(),
-            "recursion_limit": 10,
             "configurable": {"thread_id": mock_thread_id},
         }
 


### PR DESCRIPTION
We don't need the recursion limit config anynore, because we're using the [ModelCallLimit](https://docs.langchain.com/oss/python/langchain/middleware/built-in#model-call-limit) pre-built middleware.