### PR TITLE
feat: resolve data source display names from the backend

### DIFF
--- a/app/api/streaming/agent_runner.py
+++ b/app/api/streaming/agent_runner.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 from app.agent.schemas import StructuredResponse
 from app.api.schemas import ConfigDict
+from app.api.streaming.data_sources import resolve_data_source_names
 from app.api.streaming.schemas import EventData, StreamEvent, ToolCall, ToolOutput
 from app.api.streaming.security import sanitize_markdown_links
 from app.db.database import AsyncDatabase, sessionmaker
@@ -240,6 +241,8 @@ async def run_agent(
                         artifacts.append(output.artifact)
             elif event.type == "final_answer":
                 assistant_message = event.data.content
+                if event.data.structured_response is not None:
+                    await resolve_data_source_names(event.data.structured_response)
                 structured_response = event.data.structured_response
                 status = MessageStatus.SUCCESS
             elif event.type == "model_call_limit":

--- a/app/api/streaming/data_sources.py
+++ b/app/api/streaming/data_sources.py
@@ -1,0 +1,102 @@
+import asyncio
+import json
+from typing import Any
+
+import httpx
+from loguru import logger
+
+from app.settings import settings
+
+# Minimal GraphQL query to resolve a table's name and its dataset's name from the table UUID.
+TABLE_NAME_QUERY = """
+query getTableName($id: ID!) {
+    allTable(id: $id, first: 1) {
+        edges {
+            node {
+                name
+                dataset {
+                    name
+                }
+            }
+        }
+    }
+}
+"""
+
+# Base dos Dados GraphQL endpoint, used to resolve data source display names.
+_GRAPHQL_URL = f"{settings.BASEDOSDADOS_BASE_URL}/graphql"
+
+# Dedicated HTTP client + cache for resolving data source display names from table UUIDs.
+_http_client = httpx.AsyncClient(timeout=httpx.Timeout(5.0, read=60.0))
+_TABLE_NAME_CACHE: dict[str, str] = {}
+
+
+async def _resolve_table_name(table_id: str) -> str | None:
+    """Resolve a table UUID to a human-readable "{dataset_name} — {table_name}" and caches results.
+
+    Args:
+        table_id (str): A Table UUID.
+
+    Returns:
+        str | None: "{dataset_name} — {table_name}", or None if the table can't
+            be resolved (unknown UUID, missing names, network error, etc.).
+    """
+    if table_id in _TABLE_NAME_CACHE:
+        return _TABLE_NAME_CACHE[table_id]
+
+    try:
+        response = await _http_client.post(
+            url=_GRAPHQL_URL,
+            json={"query": TABLE_NAME_QUERY, "variables": {"id": table_id}},
+        )
+        response.raise_for_status()
+        data: dict = response.json()
+    except (httpx.HTTPError, json.JSONDecodeError) as e:
+        logger.warning(f"Failed to resolve name for table '{table_id}': {e!r}")
+        return None
+
+    all_tables = data.get("data", {}).get("allTable") or {}
+    edges = all_tables.get("edges", [])
+
+    if not edges:
+        return None
+
+    node = edges[0]["node"]
+    table_name = node.get("name")
+    dataset_name = (node.get("dataset") or {}).get("name")
+
+    if not table_name or not dataset_name:
+        return None
+
+    name = f"{dataset_name} — {table_name}"
+    _TABLE_NAME_CACHE[table_id] = name
+    return name
+
+
+async def resolve_data_source_names(structured_response: dict[str, Any]) -> None:
+    """Overwrite each data source's display name with a deterministic
+    "{dataset_name} — {table_name}" resolved from its table UUID.
+
+    The resolved name is authoritative; the model-provided `name` (see
+    `app.agent.schemas.DataSource`) is kept as a fallback for any source whose
+    UUID can't be resolved (unknown UUID, missing names, network error, etc.).
+    Written onto the structured response in place.
+
+    Args:
+        structured_response (dict[str, Any]): The dumped StructuredResponse whose
+            `data_sources` entries are enriched in place.
+    """
+    data_sources = structured_response.get("data_sources") or []
+    resolvable = [source for source in data_sources if source["table_id"]]
+
+    if not resolvable:
+        return
+
+    names = await asyncio.gather(
+        *(_resolve_table_name(source["table_id"]) for source in resolvable),
+        return_exceptions=True,
+    )
+
+    for source, name in zip(resolvable, names):
+        if isinstance(name, str):
+            source["name"] = name

--- a/tests/app/api/streaming/test_agent_runner.py
+++ b/tests/app/api/streaming/test_agent_runner.py
@@ -323,6 +323,8 @@ class TestProcessChunk:
         assert event.data.content == "Here is your answer."
         assert event.data.structured_response is not None
         assert event.data.structured_response["response"] == "Here is your answer."
+        # `_process_chunk` dumps the model's fields as-is; the authoritative name is resolved
+        # later in `run_agent` (see test_structured_response_is_emitted_and_persisted).
         assert event.data.structured_response["data_sources"] == [
             {"dataset_id": "ds1", "table_id": "tb1", "name": "Tabela 1"}
         ]
@@ -543,16 +545,18 @@ class TestRunAgent:
 
     async def test_structured_response_is_emitted_and_persisted(
         self,
+        monkeypatch: pytest.MonkeyPatch,
         mock_database: MagicMock,
         mock_user_message: Message,
         config: ConfigDict,
         thread_id: str,
     ):
-        """A structured final answer is streamed and persisted on the message row."""
+        """A structured final answer is streamed and persisted on the message row,
+        with each data source's display name resolved from its table UUID."""
         structured = StructuredResponse(
             response="Final answer",
             data_sources=[
-                DataSource(dataset_id="ds1", table_id="tb1", name="Tabela 1")
+                DataSource(dataset_id="ds1", table_id="tb1", name="model fallback")
             ],
             temporal_coverage=TemporalCoverage(
                 period_start="2020",
@@ -561,6 +565,16 @@ class TestRunAgent:
             ),
             sql_queries=["SELECT 1"],
             follow_up_questions=["E em 2026?"],
+        )
+
+        async def fake_resolve(structured_response: dict[str, Any]):
+            for source in structured_response.get("data_sources") or []:
+                source["name"] = "Conjunto DS1 - Tabela TB1"
+
+        resolve_names = AsyncMock(side_effect=fake_resolve)
+
+        monkeypatch.setattr(
+            "app.api.streaming.agent_runner.resolve_data_source_names", resolve_names
         )
 
         agent = MagicMock()
@@ -595,8 +609,13 @@ class TestRunAgent:
 
         assert events[0].data.structured_response is not None
         assert events[0].data.structured_response["response"] == "Final answer"
+        resolve_names.assert_awaited_once()
         assert events[0].data.structured_response["data_sources"] == [
-            {"dataset_id": "ds1", "table_id": "tb1", "name": "Tabela 1"}
+            {
+                "dataset_id": "ds1",
+                "table_id": "tb1",
+                "name": "Conjunto DS1 - Tabela TB1",
+            }
         ]
         assert events[0].data.structured_response["temporal_coverage"] == {
             "period_start": "2020",

--- a/tests/app/api/streaming/test_data_sources.py
+++ b/tests/app/api/streaming/test_data_sources.py
@@ -1,0 +1,169 @@
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+import respx
+
+from app.api.streaming.data_sources import (
+    _GRAPHQL_URL,
+    _TABLE_NAME_CACHE,
+    _resolve_table_name,
+    resolve_data_source_names,
+)
+
+
+class TestResolveTableName:
+    """Tests for the _resolve_table_name GraphQL lookup + cache."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        """Isolate tests from the process-lifetime name cache."""
+        _TABLE_NAME_CACHE.clear()
+        yield
+        _TABLE_NAME_CACHE.clear()
+
+    @staticmethod
+    def _node_response(dataset_name: str | None, table_name: str | None):
+        node = {"name": table_name, "dataset": {"name": dataset_name}}
+        return {"data": {"allTable": {"edges": [{"node": node}]}}}
+
+    @respx.mock
+    async def test_builds_dataset_dash_table_name(self):
+        """A resolved table yields '{dataset_name} — {table_name}'."""
+        respx.post(_GRAPHQL_URL).mock(
+            return_value=httpx.Response(
+                200, json=self._node_response("Diretórios Brasileiros", "Município")
+            )
+        )
+
+        assert await _resolve_table_name("tb1") == "Diretórios Brasileiros — Município"
+
+    @respx.mock
+    async def test_caches_successful_resolution(self):
+        """A second lookup for the same UUID hits the cache, not the network."""
+        route = respx.post(_GRAPHQL_URL).mock(
+            return_value=httpx.Response(
+                200, json=self._node_response("Diretórios Brasileiros", "Município")
+            )
+        )
+
+        first = await _resolve_table_name("tb1")
+        second = await _resolve_table_name("tb1")
+
+        assert first == second == "Diretórios Brasileiros — Município"
+        assert route.call_count == 1
+
+    @respx.mock
+    async def test_returns_none_when_not_found(self):
+        """An unknown UUID (no edges) resolves to None and is not cached."""
+        respx.post(_GRAPHQL_URL).mock(
+            return_value=httpx.Response(200, json={"data": {"allTable": {"edges": []}}})
+        )
+
+        assert await _resolve_table_name("missing") is None
+        assert "missing" not in _TABLE_NAME_CACHE
+
+    @respx.mock
+    async def test_returns_none_on_missing_dataset_name(self):
+        """A node missing the dataset name resolves to None."""
+        respx.post(_GRAPHQL_URL).mock(
+            return_value=httpx.Response(
+                200, json=self._node_response(None, "Município")
+            )
+        )
+
+        assert await _resolve_table_name("tb1") is None
+
+    @respx.mock
+    async def test_returns_none_on_missing_table_name(self):
+        """A node missing the table name resolves to None."""
+        respx.post(_GRAPHQL_URL).mock(
+            return_value=httpx.Response(
+                200, json=self._node_response("Diretórios Brasileiros", None)
+            )
+        )
+
+        assert await _resolve_table_name("tb1") is None
+
+    @respx.mock
+    async def test_returns_none_on_http_error(self):
+        """A backend error is swallowed and resolves to None."""
+        respx.post(_GRAPHQL_URL).mock(return_value=httpx.Response(500))
+
+        assert await _resolve_table_name("tb1") is None
+
+    @respx.mock
+    async def test_returns_none_on_json_decode_error(self):
+        """A malformed JSON body is swallowed and resolves to None."""
+        # `content=` sends the raw bytes verbatim; `json=` would serialize this
+        # to a *valid* JSON string and never trigger a decode error.
+        respx.post(_GRAPHQL_URL).mock(
+            return_value=httpx.Response(200, content=b"{'malformed': 'json'")
+        )
+
+        assert await _resolve_table_name("tb1") is None
+
+
+class TestResolveDataSourceNames:
+    """Tests for the resolve_data_source_names enrichment entry point."""
+
+    async def test_resolved_name_overwrites_model_fallback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A successful resolution overwrites the model-provided fallback name."""
+        resolve_name = AsyncMock(side_effect=lambda tid: f"Conjunto - {tid}")
+
+        monkeypatch.setattr(
+            "app.api.streaming.data_sources._resolve_table_name", resolve_name
+        )
+
+        structured = {
+            "data_sources": [
+                {"dataset_id": "ds1", "table_id": "tb1", "name": "model name 1"},
+                {"dataset_id": "ds2", "table_id": "tb2", "name": "model name 2"},
+            ]
+        }
+
+        await resolve_data_source_names(structured)
+
+        assert structured["data_sources"] == [
+            {"dataset_id": "ds1", "table_id": "tb1", "name": "Conjunto - tb1"},
+            {"dataset_id": "ds2", "table_id": "tb2", "name": "Conjunto - tb2"},
+        ]
+
+    async def test_keeps_model_fallback_when_unresolvable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A source whose UUID can't be resolved keeps the model's fallback name."""
+        monkeypatch.setattr(
+            "app.api.streaming.data_sources._resolve_table_name",
+            AsyncMock(return_value=None),
+        )
+
+        structured = {
+            "data_sources": [
+                {"dataset_id": "ds1", "table_id": "tb1", "name": "model fallback"}
+            ]
+        }
+
+        await resolve_data_source_names(structured)
+
+        assert structured["data_sources"] == [
+            {"dataset_id": "ds1", "table_id": "tb1", "name": "model fallback"}
+        ]
+
+    async def test_no_data_sources_skips_resolution(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """With no data sources the resolver is never called."""
+        resolve_name = AsyncMock()
+
+        monkeypatch.setattr(
+            "app.api.streaming.data_sources._resolve_table_name", resolve_name
+        )
+
+        await resolve_data_source_names({"data_sources": None})
+        await resolve_data_source_names({"data_sources": []})
+        await resolve_data_source_names({})
+
+        resolve_name.assert_not_awaited()


### PR DESCRIPTION
Derive each data source's display name deterministically as "{dataset_name} — {table_name}" from its table UUID, via a dedicated minimal GraphQL query (cached), and overwrite the model-provided name on the final structured response. The model's name is kept as a fallback when resolution fails (unknown UUID, missing names, or a network error).