### PR TITLE
feat: localize the chatbot by language (pt/en/es)

### DIFF
--- a/alembic/versions/4b3d2fa4a75f_add_thread_language.py
+++ b/alembic/versions/4b3d2fa4a75f_add_thread_language.py
@@ -1,0 +1,32 @@
+"""Add language column to threads table.
+
+Revision ID: 4b3d2fa4a75f
+Revises: f6ce7837e023
+Create Date: 2026-08-04 19:50:02.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "4b3d2fa4a75f"
+down_revision: Union[str, Sequence[str], None] = "f6ce7837e023"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # server_default backfills existing threads with the Portuguese default; new rows get
+    # their value from the application (ThreadPayload.language).
+    op.add_column(
+        "thread",
+        sa.Column("language", sa.String(), nullable=False, server_default="pt"),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("thread", "language")

--- a/app/api/routers/chatbot.py
+++ b/app/api/routers/chatbot.py
@@ -28,6 +28,7 @@ from app.exports import (
     ResultTooLarge,
     materialize_export,
 )
+from app.i18n import t
 from app.settings import settings
 from app.storage import generate_signed_url
 
@@ -59,6 +60,7 @@ async def create_thread(
     thread_create = ThreadCreate(
         title=thread_payload.title,
         user_id=user_id,
+        language=thread_payload.language,
     )
 
     return await database.create_thread(thread_create)
@@ -120,11 +122,23 @@ async def send_message(
     running_runs: RunningRuns,
     user_id: UserID,
 ) -> StreamingResponse:
+    thread = await database.get_thread(thread_id)
+
+    if thread is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Thread {thread_id} not found",
+        )
+
     run_id = str(uuid.uuid4())
 
     config = ConfigDict(
         run_id=run_id,
-        configurable={"thread_id": thread_id, "user_id": user_id},
+        configurable={
+            "thread_id": thread_id,
+            "user_id": user_id,
+            "language": thread.language,
+        },
     )
 
     message_create = MessageCreate(
@@ -145,6 +159,7 @@ async def send_message(
             thread_id=thread_id,
             user_message=message,
             model_uri=settings.MODEL_URI,
+            language=thread.language,
             queue=queue,
         ),
         name=f"run_agent:{run_id}",
@@ -169,28 +184,18 @@ async def send_message(
     )
 
 
-# User-facing details the frontend surfaces to the end user when a download fails.
-RESULTS_EXPIRED_DETAIL = "Estes resultados não estão mais disponíveis para download."
-
-RESULTS_TOO_LARGE_DETAIL = (
-    "Estes resultados são grandes demais para baixar em um único arquivo."
-)
-
-# Fallback base name when a query's slug yields nothing filesystem-safe.
-DEFAULT_EXPORT_FILENAME = "resultados"
-
-
-def _sanitize_filename(slug: str) -> str:
+def _sanitize_filename(slug: str, fallback: str) -> str:
     """Sanitize a query's slug into a safe base filename.
 
     Args:
         slug (str): The query's slug.
+        fallback (str): Base name to use when the slug yields nothing filesystem-safe.
 
     Returns:
         str: A filesystem-safe base filename, without extension.
     """
     filename = re.sub(r"[^\w-]+", "_", slug).strip("_")
-    return filename or DEFAULT_EXPORT_FILENAME
+    return filename or fallback
 
 
 @router.post("/messages/{message_id}/exports")
@@ -242,18 +247,20 @@ async def export_message_results(
             query_ref=query_handle.query_ref,
             destination_table=query_handle.destination_table,
             file_format=file_format,
-            filename=_sanitize_filename(query_handle.slug),
+            filename=_sanitize_filename(
+                query_handle.slug, t("default_export_filename", thread.language)
+            ),
             message_id=str(message.id),
         )
     except ResultTableExpired as e:
         raise HTTPException(
             status_code=status.HTTP_410_GONE,
-            detail=RESULTS_EXPIRED_DETAIL,
+            detail=t("results_expired", thread.language),
         ) from e
     except ResultTooLarge as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=RESULTS_TOO_LARGE_DETAIL,
+            detail=t("results_too_large", thread.language),
         ) from e
 
     signed_url = generate_signed_url(

--- a/app/api/streaming/agent_runner.py
+++ b/app/api/streaming/agent_runner.py
@@ -20,19 +20,7 @@ from app.db.models import (
     QueryHandle,
 )
 from app.exports import CollectedQueryHandle, collect_query_handles
-
-
-class ErrorMessage:
-    INTERRUPTED = (
-        "A conexão com o servidor foi interrompida. Por favor, tente novamente."
-    )
-
-    MODEL_CALL_LIMIT_REACHED = (
-        "Essa pergunta gerou um raciocínio muito longo e não consegui chegar a uma conclusão. "
-        "Por favor, tente ser mais específico ou divida sua pergunta em partes menores."
-    )
-
-    UNEXPECTED = "Ocorreu um erro inesperado. Por favor, tente novamente. Se o problema persistir, avise-nos."
+from app.i18n import DEFAULT_LANGUAGE, language_directive, t
 
 
 def _truncate_json(
@@ -93,11 +81,14 @@ def _truncate_json(
     return json.dumps(data, ensure_ascii=False, indent=2)
 
 
-def _process_chunk(chunk: dict[str, Any]) -> StreamEvent | None:
+def _process_chunk(
+    chunk: dict[str, Any], language: str = DEFAULT_LANGUAGE
+) -> StreamEvent | None:
     """Process a streaming chunk from a react agent workflow into a StreamEvent.
 
     Args:
         chunk (dict[str, Any]): A raw update chunk from the agent workflow.
+        language (str): The thread's language, for localizing server-emitted content.
 
     Returns:
         StreamEvent | None: Structured event or None if the chunk is ignored:
@@ -192,7 +183,7 @@ def _process_chunk(chunk: dict[str, Any]) -> StreamEvent | None:
         update = chunk["ModelCallLimitMiddleware.before_model"] or {}
         if update.get("jump_to") == "end":
             event_data = EventData(
-                content=ErrorMessage.MODEL_CALL_LIMIT_REACHED,
+                content=t("error_model_call_limit", language),
                 tool_calls=None,
             )
             return StreamEvent(type="model_call_limit", data=event_data)
@@ -231,6 +222,7 @@ async def run_agent(
     user_message: Message,
     model_uri: str,
     queue: asyncio.Queue[StreamEvent],
+    language: str = DEFAULT_LANGUAGE,
 ):
     """Run the agent to completion and push events onto the queue.
 
@@ -245,6 +237,8 @@ async def run_agent(
         thread_id (str): Thread unique identifier.
         user_message (Message): User message.
         model_uri (str): Model URI.
+        language (str): The thread's language; sets the response-language default and
+            localizes server-emitted error messages.
         queue (asyncio.Queue[StreamEvent]): Events queue.
     """
     events = []
@@ -253,16 +247,22 @@ async def run_agent(
     collected_handles: list[CollectedQueryHandle] = []
     status: MessageStatus | None = None
 
+    # Prepend the language directive to the model input only — the persisted user Message
+    # (created by the router) keeps the user's clean text. This sets the site's language as
+    # the default while letting the model honor a user who writes in another language.
+    # A dynamic-prompt middleware would keep it out of checkpoint history entirely; see PR notes.
+    model_input = f"{language_directive(language)}\n\n{user_message.content}"
+
     try:
         async for mode, chunk in agent.astream(  # pragma: no cover
-            input={"messages": [{"role": "user", "content": user_message.content}]},
+            input={"messages": [{"role": "user", "content": model_input}]},
             config=config,
             stream_mode=["updates", "values"],
         ):
             if mode == "values":
                 continue
 
-            event = _process_chunk(chunk)
+            event = _process_chunk(chunk, language)
 
             if event is None:
                 continue
@@ -290,12 +290,12 @@ async def run_agent(
             await queue.put(event)
     except asyncio.CancelledError:
         if status is None:
-            assistant_message = ErrorMessage.INTERRUPTED
+            assistant_message = t("error_interrupted", language)
             status = MessageStatus.INTERRUPTED
         raise
     except Exception:
         logger.exception(f"Unexpected error in run {config['run_id']}:")
-        assistant_message = ErrorMessage.UNEXPECTED
+        assistant_message = t("error_unexpected", language)
         status = MessageStatus.ERROR
         event = StreamEvent(
             type="error",

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -3,9 +3,11 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
-from pydantic import JsonValue, computed_field
+from pydantic import JsonValue, computed_field, field_validator
 from sqlalchemy import Enum as SAEnum
 from sqlmodel import JSON, TIMESTAMP, Column, Field, Integer, Relationship, SQLModel
+
+from app.i18n import DEFAULT_LANGUAGE, normalize_language
 
 
 # =============================================================================
@@ -13,6 +15,14 @@ from sqlmodel import JSON, TIMESTAMP, Column, Field, Integer, Relationship, SQLM
 # =============================================================================
 class ThreadPayload(SQLModel):
     title: str
+    # Captured at creation from the site's locale (pt/en/es). Steers the assistant's response
+    # language and localizes server-emitted messages. Stored as a plain code; see app.i18n.
+    language: str = Field(default=DEFAULT_LANGUAGE)
+
+    @field_validator("language")
+    @classmethod
+    def _normalize_language(cls, value: str) -> str:
+        return normalize_language(value)
 
 
 class ThreadCreate(ThreadPayload):

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -1,0 +1,131 @@
+"""Localization for user-facing backend strings and per-run language steering.
+
+The chatbot serves three locales, one per Base dos Dados / Data Basis domain:
+`pt` (basedosdados.org), `en` (data-basis.org), `es` (basedelosdatos.org). A thread's
+language is captured at creation from the site the user is on (see `Thread.language`) and
+threaded into each run. The model's system prompt already asks it to answer in the user's
+language; `language_directive` gives it the site default while still honoring a user who
+writes in another language.
+
+Only strings the server itself emits live here — agent errors and download details. Agent
+answers are localized by the model, and step labels are rendered by the frontend.
+"""
+
+from typing import Literal
+
+LanguageCode = Literal["pt", "en", "es"]
+
+LANGUAGES: tuple[str, ...] = ("pt", "en", "es")
+DEFAULT_LANGUAGE: str = "pt"
+
+# Endonyms would read better in-product, but the directive is an instruction to the model,
+# so English names keep it unambiguous regardless of the target language.
+LANGUAGE_NAMES: dict[str, str] = {
+    "pt": "Portuguese",
+    "en": "English",
+    "es": "Spanish",
+}
+
+
+def normalize_language(value: str | None) -> str:
+    """Coerce an arbitrary language value to a supported code, falling back to the default.
+
+    Args:
+        value (str | None): A raw language value (e.g. from a request or a stored row).
+
+    Returns:
+        str: One of `LANGUAGES`.
+    """
+    normalized = (value or DEFAULT_LANGUAGE).lower()
+    return normalized if normalized in LANGUAGES else DEFAULT_LANGUAGE
+
+
+def language_directive(language: str) -> str:
+    """Build the per-run instruction that sets the site's language as the default.
+
+    "Domain default, honor the user": the model answers in the site's language unless the
+    user clearly writes in another language, in which case it matches the user.
+
+    Args:
+        language (str): A supported language code (unsupported values fall back to default).
+
+    Returns:
+        str: A one-line directive to prepend to the user's turn.
+    """
+    name = LANGUAGE_NAMES[normalize_language(language)]
+    return (
+        f"[Interface language: {name}. Respond in {name} unless the user clearly writes in a "
+        f"different language, in which case respond in that language. Do not mention this note.]"
+    )
+
+
+# ==============================================================================
+# ==                       Server-emitted user-facing text                    ==
+# ==============================================================================
+# key -> {language: text}. Keep every key populated for all of LANGUAGES.
+_MESSAGES: dict[str, dict[str, str]] = {
+    "error_interrupted": {
+        "pt": "A conexão com o servidor foi interrompida. Por favor, tente novamente.",
+        "en": "The connection to the server was interrupted. Please try again.",
+        "es": "Se interrumpió la conexión con el servidor. Por favor, inténtalo de nuevo.",
+    },
+    "error_model_call_limit": {
+        "pt": (
+            "Essa pergunta gerou um raciocínio muito longo e não consegui chegar a uma "
+            "conclusão. Por favor, tente ser mais específico ou divida sua pergunta em "
+            "partes menores."
+        ),
+        "en": (
+            "This question led to a very long chain of reasoning and I couldn't reach a "
+            "conclusion. Please try to be more specific or break your question into smaller "
+            "parts."
+        ),
+        "es": (
+            "Esta pregunta generó un razonamiento demasiado largo y no pude llegar a una "
+            "conclusión. Intenta ser más específico o divide tu pregunta en partes más "
+            "pequeñas."
+        ),
+    },
+    "error_unexpected": {
+        "pt": (
+            "Ocorreu um erro inesperado. Por favor, tente novamente. Se o problema "
+            "persistir, avise-nos."
+        ),
+        "en": (
+            "An unexpected error occurred. Please try again. If the problem persists, let "
+            "us know."
+        ),
+        "es": (
+            "Ocurrió un error inesperado. Inténtalo de nuevo. Si el problema persiste, "
+            "avísanos."
+        ),
+    },
+    "results_expired": {
+        "pt": "Estes resultados não estão mais disponíveis para download.",
+        "en": "These results are no longer available for download.",
+        "es": "Estos resultados ya no están disponibles para descargar.",
+    },
+    "results_too_large": {
+        "pt": "Estes resultados são grandes demais para baixar em um único arquivo.",
+        "en": "These results are too large to download in a single file.",
+        "es": "Estos resultados son demasiado grandes para descargar en un solo archivo.",
+    },
+    "default_export_filename": {
+        "pt": "resultados",
+        "en": "results",
+        "es": "resultados",
+    },
+}
+
+
+def t(key: str, language: str) -> str:
+    """Return the localized string for `key` in `language`.
+
+    Args:
+        key (str): A key present in `_MESSAGES`.
+        language (str): A language code (unsupported values fall back to the default).
+
+    Returns:
+        str: The localized string.
+    """
+    return _MESSAGES[key][normalize_language(language)]

--- a/tests/app/api/routers/test_chatbot.py
+++ b/tests/app/api/routers/test_chatbot.py
@@ -12,7 +12,7 @@ from langchain_core.messages import AIMessage
 from pytest_mock import MockerFixture
 
 from app.api.dependencies import get_database, get_feedback_sender
-from app.api.routers.chatbot import DEFAULT_EXPORT_FILENAME, _sanitize_filename
+from app.api.routers.chatbot import _sanitize_filename
 from app.api.streaming.schemas import StreamEvent
 from app.db.database import AsyncDatabase
 from app.db.models import (
@@ -880,9 +880,9 @@ class TestSanitizeFilename:
         ],
     )
     def test_sanitizes_slug(self, slug: str, expected: str):
-        assert _sanitize_filename(slug) == expected
+        assert _sanitize_filename(slug, "resultados") == expected
 
     @pytest.mark.parametrize("slug", ["", "   ", "!!!", "/", "..."])
     def test_falls_back_when_nothing_usable_remains(self, slug: str):
-        """A slug that sanitizes to empty falls back to the default, never ''."""
-        assert _sanitize_filename(slug) == DEFAULT_EXPORT_FILENAME
+        """A slug that sanitizes to empty falls back to the provided fallback, never ''."""
+        assert _sanitize_filename(slug, "resultados") == "resultados"

--- a/tests/app/api/streaming/test_agent_runner.py
+++ b/tests/app/api/streaming/test_agent_runner.py
@@ -16,7 +16,6 @@ from app.agent.schemas import (
 )
 from app.api.schemas import ConfigDict
 from app.api.streaming.agent_runner import (
-    ErrorMessage,
     _process_chunk,
     _truncate_json,
     run_agent,
@@ -24,6 +23,7 @@ from app.api.streaming.agent_runner import (
 from app.api.streaming.schemas import StreamEvent
 from app.db.models import Message, MessageCreate, MessageRole, MessageStatus
 from app.exports import OFFERED_EXPORT_FORMATS
+from app.i18n import t
 
 MODEL_URI = "mock-model"
 
@@ -531,7 +531,7 @@ class TestProcessChunk:
 
         assert event is not None
         assert event.type == "model_call_limit"
-        assert event.data.content == ErrorMessage.MODEL_CALL_LIMIT_REACHED
+        assert event.data.content == t("error_model_call_limit", "pt")
 
     def test_model_call_limit_passthrough_chunk_returns_none(self):
         """Test before_model passthrough chunk (None payload) returns None."""
@@ -919,14 +919,14 @@ class TestRunAgent:
 
         events = await self._drain(queue)
         assert [e.type for e in events] == ["error", "complete"]
-        assert events[0].data.content == ErrorMessage.UNEXPECTED
+        assert events[0].data.content == t("error_unexpected", "pt")
         assert events[0].data.error_details == {"reason": "agent_failed"}
 
         mock_database.create_message.assert_called_once()
         message = mock_database.create_message.call_args[0][0]
         assert isinstance(message, MessageCreate)
         assert message.status == MessageStatus.ERROR
-        assert message.content == ErrorMessage.UNEXPECTED
+        assert message.content == t("error_unexpected", "pt")
 
     async def test_model_call_limit_persists_with_dedicated_status(
         self,
@@ -958,14 +958,14 @@ class TestRunAgent:
 
         events = await self._drain(queue)
         assert [e.type for e in events] == ["model_call_limit", "complete"]
-        assert events[0].data.content == ErrorMessage.MODEL_CALL_LIMIT_REACHED
+        assert events[0].data.content == t("error_model_call_limit", "pt")
         assert events[-1].data.run_id == config["run_id"]
 
         mock_database.create_message.assert_called_once()
         message = mock_database.create_message.call_args[0][0]
         assert isinstance(message, MessageCreate)
         assert message.status == MessageStatus.MODEL_CALL_LIMIT
-        assert message.content == ErrorMessage.MODEL_CALL_LIMIT_REACHED
+        assert message.content == t("error_model_call_limit", "pt")
 
     async def test_complete_still_emitted_when_db_write_fails(
         self,
@@ -1112,7 +1112,7 @@ class TestRunAgent:
         message = mock_database.create_message.call_args[0][0]
         assert isinstance(message, MessageCreate)
         assert message.status == MessageStatus.INTERRUPTED
-        assert message.content == ErrorMessage.INTERRUPTED
+        assert message.content == t("error_interrupted", "pt")
 
     async def test_cancellation_after_final_answer_preserves_success(
         self,

--- a/tests/app/test_i18n.py
+++ b/tests/app/test_i18n.py
@@ -1,0 +1,50 @@
+import pytest
+
+from app.i18n import (
+    DEFAULT_LANGUAGE,
+    LANGUAGES,
+    _MESSAGES,
+    language_directive,
+    normalize_language,
+    t,
+)
+
+
+class TestNormalizeLanguage:
+    @pytest.mark.parametrize("value", ["pt", "en", "es"])
+    def test_supported_codes_pass_through(self, value: str):
+        assert normalize_language(value) == value
+
+    @pytest.mark.parametrize("value", ["PT", "En", "ES"])
+    def test_case_is_normalized(self, value: str):
+        assert normalize_language(value) == value.lower()
+
+    @pytest.mark.parametrize("value", [None, "", "fr", "de", "unknown"])
+    def test_unsupported_falls_back_to_default(self, value):
+        assert normalize_language(value) == DEFAULT_LANGUAGE
+
+
+class TestTranslate:
+    def test_every_key_covers_every_language(self):
+        for key, translations in _MESSAGES.items():
+            assert set(translations) == set(LANGUAGES), f"'{key}' is missing a language"
+            assert all(v.strip() for v in translations.values()), f"'{key}' has empty text"
+
+    def test_returns_language_specific_text(self):
+        assert t("results_expired", "en") != t("results_expired", "pt")
+        assert t("results_expired", "en") != t("results_expired", "es")
+
+    def test_unsupported_language_falls_back_to_default(self):
+        assert t("error_unexpected", "fr") == t("error_unexpected", DEFAULT_LANGUAGE)
+
+
+class TestLanguageDirective:
+    @pytest.mark.parametrize(
+        ("language", "expected_name"),
+        [("pt", "Portuguese"), ("en", "English"), ("es", "Spanish")],
+    )
+    def test_names_the_target_language(self, language: str, expected_name: str):
+        assert expected_name in language_directive(language)
+
+    def test_unsupported_language_falls_back_to_default_name(self):
+        assert "Portuguese" in language_directive("fr")


### PR DESCRIPTION
## What & why

Part of the Data Basis multilingual effort: give users on the English (data-basis.org) and Spanish (basedelosdatos.org) domains a chatbot experience fully in their language, matching Portuguese users on basedosdados.org.

The agent already ends its system prompt with *"Always respond in the user's language,"* so it mirrors the language a user types in. This PR adds the missing pieces:

1. **Each thread has a `language`** (`pt`/`en`/`es`), captured at creation from the site domain — the "each chat's language" the effort needs, and useful for analytics.
2. **The site's language is the response default**, while a user who clearly writes in another language is still honored ("domain default, honor the user").
3. **Server-emitted strings are localized** — the agent error messages (`agent_runner.py`) and download error/detail strings (`routers/chatbot.py`) were hardcoded Portuguese. Agent *answers* remain localized by the model; step labels are rendered by the frontend, so they aren't touched here.

## Changes

- **`app/i18n.py`** (new) — supported languages, `normalize_language`, `language_directive` (the per-run steering instruction), and a small catalog of server-emitted strings with `t(key, language)`.
- **`app/db/models.py`** — `Thread.language` on `ThreadPayload` (so clients set it on create) with normalization; defaults to `pt`.
- **`alembic/versions/4b3d2fa4a75f_add_thread_language.py`** (new) — adds the column, `server_default='pt'` to backfill existing threads.
- **`app/api/routers/chatbot.py`** — persist `language` on thread creation; load the thread on `send_message` to put `language` into the run config; localize the download error/detail strings and the export-filename fallback.
- **`app/api/streaming/agent_runner.py`** — localize `INTERRUPTED` / `MODEL_CALL_LIMIT` / `UNEXPECTED` by language; prepend the language directive to the model input.
- **tests** — updated the two tests that referenced the removed `ErrorMessage` / `DEFAULT_EXPORT_FILENAME` and the changed `_sanitize_filename` signature; added `tests/app/test_i18n.py`.

## Contract for the frontend

For this to take effect, the website must send `language` in the `POST /api/v1/chatbot/threads` body (from the active i18n locale). Until it does, `language` defaults to `pt` — i.e. current behavior is preserved. Backward-compatible.

## Open point for reviewers

The language directive is **prepended to the model input** on each run; the persisted user `Message` keeps its clean text, but the directive does enter the LangGraph checkpoint history. A **dynamic-prompt middleware** (reading `config["configurable"]["language"]`) would keep it out of history entirely and is the cleaner long-term approach — I kept it out of this PR to avoid depending on the exact `create_agent` middleware API without a reviewer who knows the version. Happy to switch to that if preferred.

## Test plan

- [ ] `POST /threads` with `{"title": ..., "language": "en"}` persists `language="en"`; omitting it defaults to `pt`; an unsupported value normalizes to `pt`.
- [ ] A thread with `language="en"`/`"es"` yields English/Spanish error messages on interruption / model-call-limit / unexpected error, and English/Spanish download-failure details.
- [ ] Existing rows are backfilled to `pt` by the migration.
- [ ] `uv run pytest` green.

---
🚧 **Draft** — opened for review of the approach (esp. the language-steering mechanism) before it's finalized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
