### PR TITLE
fix: enforce thread ownership on chatbot endpoints (IDOR)

### DIFF
--- a/app/api/dependencies/auth.py
+++ b/app/api/dependencies/auth.py
@@ -39,7 +39,7 @@ async def _is_user_authorized(token: str) -> bool:
     return payload["has_chatbot_access"]
 
 
-async def get_user_id(token: Annotated[str | None, Depends(oauth2_scheme)]) -> int:
+async def get_user_id(token: Annotated[str | None, Depends(oauth2_scheme)]) -> str:
     if settings.AUTH_DEV_MODE and settings.ENVIRONMENT == "development":
         logger.warning(
             "AUTH DEV MODE ENABLED: bypassing JWT validation, "

--- a/app/api/routers/chatbot.py
+++ b/app/api/routers/chatbot.py
@@ -10,10 +10,12 @@ from app.api.dependencies import Agent, AsyncDB, FeedbackSender, RunningRuns, Us
 from app.api.schemas import ConfigDict, UserMessage
 from app.api.streaming import run_agent, stream_events
 from app.api.streaming.schemas import StreamEvent
+from app.db.database import AsyncDatabase
 from app.db.models import (
     FeedbackCreate,
     FeedbackPayload,
     FeedbackPublic,
+    Message,
     MessageCreate,
     MessagePublic,
     MessageRole,
@@ -32,6 +34,63 @@ from app.settings import settings
 from app.storage import generate_signed_url
 
 router = APIRouter(prefix="/chatbot")
+
+
+async def _authorize_thread(
+    database: AsyncDatabase, thread_id: str, user_id: str
+) -> Thread:
+    """Fetch a thread and verify the caller owns it.
+
+    Args:
+        database (AsyncDatabase): The database repository.
+        thread_id (str): The thread the caller is trying to reach.
+        user_id (str): The authenticated caller.
+
+    Returns:
+        Thread: The thread, guaranteed to belong to `user_id`.
+
+    Raises:
+        HTTPException: 404 whether the thread is missing or owned by someone else.
+    """
+    thread = await database.get_thread(thread_id)
+
+    if thread is None or str(thread.user_id) != user_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Thread {thread_id} not found",
+        )
+
+    return thread
+
+
+async def _authorize_message(
+    database: AsyncDatabase, message_id: str, user_id: str
+) -> Message:
+    """Fetch a message and verify the caller owns the thread it belongs to.
+
+    Args:
+        database (AsyncDatabase): The database repository.
+        message_id (str): The message the caller is trying to reach.
+        user_id (str): The authenticated caller.
+
+    Returns:
+        Message: The message, whose thread is guaranteed to belong to `user_id`.
+
+    Raises:
+        HTTPException: 404 whether the message is missing or the caller doesn't own its thread.
+    """
+    message = await database.get_message(message_id)
+    thread = (
+        await database.get_thread(message.thread_id) if message is not None else None
+    )
+
+    if message is None or thread is None or str(thread.user_id) != user_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Message {message_id} not found",
+        )
+
+    return message
 
 
 @router.get("/threads")
@@ -71,13 +130,9 @@ async def delete_thread_and_checkpoints(
     agent: Agent,
     user_id: UserID,
 ):
-    thread = await database.delete_thread(thread_id)
+    await _authorize_thread(database, thread_id, user_id)
 
-    if thread is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Thread {thread_id} not found",
-        )
+    await database.delete_thread(thread_id)
 
     if agent.checkpointer is not None:
         await agent.checkpointer.adelete_thread(thread_id)
@@ -96,13 +151,7 @@ async def list_messages(
             ),
         )
 
-    thread = await database.get_thread(thread_id)
-
-    if thread is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Thread {thread_id} not found",
-        )
+    thread = await _authorize_thread(database, thread_id, user_id)
 
     return await database.get_messages(thread.id, order_by)
 
@@ -120,6 +169,8 @@ async def send_message(
     running_runs: RunningRuns,
     user_id: UserID,
 ) -> StreamingResponse:
+    await _authorize_thread(database, thread_id, user_id)
+
     run_id = str(uuid.uuid4())
 
     config = ConfigDict(
@@ -210,23 +261,7 @@ async def export_message_results(
             ),
         )
 
-    message = await database.get_message(message_id)
-
-    if message is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Message {message_id} not found",
-        )
-
-    thread = await database.get_thread(message.thread_id)
-
-    # Identical 404 whether the message is missing or the caller doesn't own its
-    # thread, so a non-owner can't tell the two apart (IDOR protection).
-    if thread is None or str(thread.user_id) != user_id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Message {message_id} not found",
-        )
+    message = await _authorize_message(database, message_id, user_id)
 
     query_handle = await database.get_query_handle(message.id, query_ref)
 
@@ -274,6 +309,8 @@ async def upsert_feedback(
     feedback_sender: FeedbackSender,
     user_id: UserID,
 ):
+    await _authorize_message(database, message_id, user_id)
+
     feedback_create = FeedbackCreate(
         **feedback_payload.model_dump(exclude_unset=True),
         message_id=message_id,

--- a/app/db/database.py
+++ b/app/db/database.py
@@ -114,12 +114,12 @@ class AsyncDatabase:
         return thread
 
     async def get_threads(
-        self, user_id: int, order_by: str | None = None
+        self, user_id: str | UUID, order_by: str | None = None
     ) -> list[Thread]:
         """Get all threads that belongs to a user.
 
         Args:
-            user_id (int): The user unique identifier.
+            user_id (str | UUID): The user unique identifier.
             order_by (str | None, optional): A field by which results should be ordered. Defaults to None.
 
         Returns:

--- a/tests/app/api/routers/test_chatbot.py
+++ b/tests/app/api/routers/test_chatbot.py
@@ -83,9 +83,20 @@ def mock_is_user_authorized(monkeypatch: pytest.MonkeyPatch):
 @pytest.fixture
 def access_token(user_id: str) -> str:
     """Generate a valid JWT access token for testing."""
-    payload = {"uuid": user_id}
     return jwt.encode(
-        payload, settings.JWT_SECRET_KEY, algorithm=settings.JWT_ALGORITHM
+        {"uuid": user_id},
+        settings.JWT_SECRET_KEY,
+        algorithm=settings.JWT_ALGORITHM,
+    )
+
+
+@pytest.fixture
+def other_access_token() -> str:
+    """A valid JWT for a different user — someone who owns none of the fixtures."""
+    return jwt.encode(
+        {"uuid": str(uuid.uuid4())},
+        settings.JWT_SECRET_KEY,
+        algorithm=settings.JWT_ALGORITHM,
     )
 
 
@@ -289,6 +300,23 @@ class TestDeleteThreadEndpoint:
         response = client.delete(url=f"/api/v1/chatbot/threads/{uuid.uuid4()}")
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
+    async def test_non_owner_cannot_delete_thread(
+        self,
+        client: TestClient,
+        other_access_token: str,
+        thread: Thread,
+        database: AsyncDatabase,
+    ):
+        """A user who does not own the thread gets 404 and the thread survives (IDOR)."""
+        response = client.delete(
+            url=f"/api/v1/chatbot/threads/{thread.id}",
+            headers={"Authorization": f"Bearer {other_access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        # The thread must not have been (soft-)deleted by the non-owner.
+        assert await database.get_thread(thread.id) is not None
+
 
 class TestListMessagesEndpoint:
     """Tests for GET /api/v1/chatbot/threads/{thread_id}/messages"""
@@ -433,6 +461,22 @@ class TestListMessagesEndpoint:
         response = client.get(url=f"/api/v1/chatbot/threads/{thread.id}/messages")
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
+    async def test_non_owner_cannot_list_messages(
+        self,
+        client: TestClient,
+        other_access_token: str,
+        messages_factory: MessagesFactory,
+    ):
+        """A user who does not own the thread gets 404, not its messages (IDOR)."""
+        user_message, _ = await messages_factory()
+
+        response = client.get(
+            url=f"/api/v1/chatbot/threads/{user_message.thread_id}/messages",
+            headers={"Authorization": f"Bearer {other_access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
 
 class TestSendMessageEndpoint:
     """Tests for POST /api/v1/chatbot/threads/{thread_id}/messages"""
@@ -480,6 +524,24 @@ class TestSendMessageEndpoint:
             json={"content": "Hello, chatbot!"},
         )
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    async def test_non_owner_cannot_send_message(
+        self,
+        client: TestClient,
+        other_access_token: str,
+        thread: Thread,
+        database: AsyncDatabase,
+    ):
+        """A user who does not own the thread gets 404 and no message is written (IDOR)."""
+        response = client.post(
+            url=f"/api/v1/chatbot/threads/{thread.id}/messages",
+            json={"content": "Hello, chatbot!"},
+            headers={"Authorization": f"Bearer {other_access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        # No message was injected into the victim's thread.
+        assert await database.get_messages(thread.id) == []
 
     def test_send_message_persists_when_client_disconnects(
         self, client: TestClient, access_token: str, thread: Thread
@@ -607,6 +669,21 @@ class TestUpsertFeedbackEndpoint:
             json={"rating": FeedbackRating.POSITIVE.value},
         )
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_non_owner_cannot_upsert_feedback(
+        self,
+        client: TestClient,
+        other_access_token: str,
+        assistant_message: Message,
+    ):
+        """A user who does not own the message's thread gets 404 (IDOR)."""
+        response = client.put(
+            url=f"/api/v1/chatbot/messages/{assistant_message.id}/feedback",
+            json={"rating": FeedbackRating.POSITIVE.value},
+            headers={"Authorization": f"Bearer {other_access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 class TestExportMessageResultsEndpoint:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,7 +76,7 @@ async def user_id() -> str:
 # Thread Fixtures
 # =============================================================
 @pytest.fixture
-def thread_create(user_id: int) -> ThreadCreate:
+def thread_create(user_id: str) -> ThreadCreate:
     """Mock ThreadCreate instance for testing."""
     return ThreadCreate(title="Mock Thread", user_id=user_id)
 
@@ -88,7 +88,7 @@ async def thread(database: AsyncDatabase, thread_create: ThreadCreate) -> Thread
 
 
 @pytest_asyncio.fixture
-async def thread_factory(database: AsyncDatabase, user_id: int) -> ThreadFactory:
+async def thread_factory(database: AsyncDatabase, user_id: str) -> ThreadFactory:
     """Factory to create multiple threads in a single test."""
 
     async def factory(title: str) -> Thread:


### PR DESCRIPTION
Four endpoints accepted an object id and acted on it without checking that the authenticated caller owned it: delete a thread, list a thread's messages, post to a thread, and upsert feedback on a message. Any authenticated user could reach another user's data by id.

Add _authorize_thread / _authorize_message helpers that resolve the owning thread and return an identical 404 whether the object is missing or owned by someone else, matching the existing check in the export endpoint (now refactored onto the shared helper).

Also correct the stale `int` type on the user id (it is a uuid string).