### PR TITLE
feat: localize the chatbot's grounding & source metadata by thread language

### DIFF
--- a/app/agent/tools/api.py
+++ b/app/agent/tools/api.py
@@ -1,6 +1,7 @@
 import json
 
 import httpx
+from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 
 from app.agent.tools.exceptions import handle_tool_errors
@@ -12,6 +13,7 @@ from app.agent.tools.models import (
     TableOverview,
 )
 from app.agent.tools.queries import DATASET_DETAILS_QUERY, TABLE_DETAILS_QUERY
+from app.i18n import localized_field, normalize_language
 from app.settings import settings
 
 # httpx default timeout
@@ -32,15 +34,49 @@ SEARCH_URL = f"{settings.BASEDOSDADOS_BASE_URL}/search/"
 # URL for fetching dataset details
 GRAPHQL_URL = f"{settings.BASEDOSDADOS_BASE_URL}/graphql"
 
-# URL for fetching usage guides
-BASE_USAGE_GUIDE_URL = "https://raw.githubusercontent.com/basedosdados/website/refs/heads/main/next/content/userGuide/pt"
+# Base URL for fetching usage guides; the language subpath (pt/en/es) is appended
+# per request, falling back to pt when a localized guide does not exist yet.
+BASE_USAGE_GUIDE_URL = "https://raw.githubusercontent.com/basedosdados/website/refs/heads/main/next/content/userGuide"
 
 _client = httpx.AsyncClient(timeout=httpx.Timeout(TIMEOUT, read=READ_TIMEOUT))
 
 
+def _config_language(config: RunnableConfig) -> str:
+    """Read the thread's language from the injected run config (pt default).
+
+    The language is set on `config["configurable"]["language"]` when the agent
+    run is dispatched (see the chatbot router). LangChain injects the run config
+    into any tool that declares a `RunnableConfig` parameter, without exposing it
+    to the model, so the tools can localize the metadata they return.
+    """
+    return normalize_language((config.get("configurable") or {}).get("language"))
+
+
+async def _fetch_usage_guide(gcp_dataset_id: str, language: str) -> str | None:
+    """Fetch a dataset's usage-guide markdown for `language`, falling back to pt.
+
+    Localized guides may not exist yet (only pt is populated today), so a missing
+    localized file falls back to the pt guide.
+
+    Args:
+        gcp_dataset_id (str): The BigQuery dataset id (its dashes form the filename).
+        language (str): The thread's language ("pt", "en", "es").
+
+    Returns:
+        str | None: The guide markdown, or None if no guide exists in any language.
+    """
+    filename = gcp_dataset_id.replace("_", "-")
+    locales = ["pt"] if language == "pt" else [language, "pt"]
+    for locale in locales:
+        response = await _client.get(f"{BASE_USAGE_GUIDE_URL}/{locale}/{filename}.md")
+        if response.status_code == httpx.codes.OK:
+            return response.text.strip()
+    return None
+
+
 @tool
 @handle_tool_errors
-async def search_datasets(query: str) -> str:
+async def search_datasets(query: str, config: RunnableConfig) -> str:
     """Search for datasets in Base dos Dados using keywords.
 
     CRITICAL: Use individual KEYWORDS only, not full sentences. The search engine uses Elasticsearch.
@@ -61,9 +97,19 @@ async def search_datasets(query: str) -> str:
 
     Next step: Use `get_dataset_details()` with returned dataset IDs.
     """
+    # The /search/ endpoint is locale-aware: it matches the localized text field
+    # and returns name/description/themes/tags/organizations in `locale`, each
+    # falling back to pt server-side.
+    language = _config_language(config)
+
     response = await _client.get(
         url=SEARCH_URL,
-        params={"contains": "tables", "q": query, "page_size": PAGE_SIZE},
+        params={
+            "contains": "tables",
+            "q": query,
+            "page_size": PAGE_SIZE,
+            "locale": language,
+        },
     )
 
     response.raise_for_status()
@@ -89,7 +135,7 @@ async def search_datasets(query: str) -> str:
 
 @tool
 @handle_tool_errors
-async def get_dataset_details(dataset_id: str) -> str:
+async def get_dataset_details(dataset_id: str, config: RunnableConfig) -> str:
     """Get comprehensive details about a specific dataset including all its tables.
 
     Use AFTER `search_datasets()` to understand data structure before writing queries.
@@ -129,29 +175,31 @@ async def get_dataset_details(dataset_id: str) -> str:
 
     dataset = dataset_edges[0]["node"]
 
+    language = _config_language(config)
+
     dataset_id = dataset["id"].split("DatasetNode:")[-1]
-    dataset_name = dataset["name"]
-    dataset_description = dataset.get("description")
+    dataset_name = localized_field(dataset, "name", language)
+    dataset_description = localized_field(dataset, "description", language)
 
     # Tags
     dataset_tags = []
 
     for edge in dataset.get("tags", {}).get("edges", []):
-        if tag := edge.get("node", {}).get("name"):
+        if tag := localized_field(edge.get("node", {}), "name", language):
             dataset_tags.append(tag)
 
     # Themes
     dataset_themes = []
 
     for edge in dataset.get("themes", {}).get("edges", []):
-        if theme := edge.get("node", {}).get("name"):
+        if theme := localized_field(edge.get("node", {}), "name", language):
             dataset_themes.append(theme)
 
     # Organizations
     dataset_organizations = []
 
     for edge in dataset.get("organizations", {}).get("edges", []):
-        if org := edge.get("node", {}).get("name"):
+        if org := localized_field(edge.get("node", {}), "name", language):
             dataset_organizations.append(org)
 
     # Tables
@@ -162,8 +210,8 @@ async def get_dataset_details(dataset_id: str) -> str:
         table = edge["node"]
 
         table_id = table["id"].split("TableNode:")[-1]
-        table_name = table["name"]
-        table_description = table.get("description")
+        table_name = localized_field(table, "name", language)
+        table_description = localized_field(table, "description", language)
 
         cloud_table_edges = table["cloudTables"]["edges"]
         if cloud_table_edges:
@@ -185,16 +233,11 @@ async def get_dataset_details(dataset_id: str) -> str:
             )
         )
 
-    # Fetch usage guide
+    # Fetch usage guide (localized, pt fallback)
     usage_guide = None
 
     if gcp_dataset_id is not None:
-        filename = gcp_dataset_id.replace("_", "-")
-
-        response = await _client.get(f"{BASE_USAGE_GUIDE_URL}/{filename}.md")
-
-        if response.status_code == httpx.codes.OK:
-            usage_guide = response.text.strip()
+        usage_guide = await _fetch_usage_guide(gcp_dataset_id, language)
 
     result = Dataset(
         id=dataset_id,
@@ -212,7 +255,7 @@ async def get_dataset_details(dataset_id: str) -> str:
 
 @tool
 @handle_tool_errors
-async def get_table_details(table_id: str) -> str:
+async def get_table_details(table_id: str, config: RunnableConfig) -> str:
     """Get comprehensive details about a specific table including all its columns.
 
     Use AFTER `get_dataset_details()` to understand table structure before writing queries.
@@ -253,9 +296,11 @@ async def get_table_details(table_id: str) -> str:
 
     table = table_edges[0]["node"]
 
+    language = _config_language(config)
+
     table_id = table["id"].split("TableNode:")[-1]
-    table_name = table["name"]
-    table_description = table.get("description")
+    table_name = localized_field(table, "name", language)
+    table_description = localized_field(table, "description", language)
     table_temporal_coverage = table.get("temporalCoverage") or {}
 
     cloud_table_edges = table["cloudTables"]["edges"]
@@ -293,7 +338,7 @@ async def get_table_details(table_id: str) -> str:
             Column(
                 name=column["name"],
                 type=column["bigqueryType"]["name"],
-                description=column.get("description"),
+                description=localized_field(column, "description", language),
                 unit=column.get("measurementUnit"),
                 reference_table_id=directory_table_id,
                 needs_decoding=column["coveredByDictionary"],

--- a/app/agent/tools/queries.py
+++ b/app/agent/tools/queries.py
@@ -1,29 +1,45 @@
+# GraphQL queries fetch the explicit modeltranslation columns
+# (`namePt`/`nameEn`/`nameEs`, `descriptionPt`/...) rather than the unqualified
+# `name`/`description` accessors, so the caller can select the thread's language
+# with a pt fallback (see `app.i18n.localized_field`). Column *names* stay as the
+# real BigQuery identifiers and are never localized.
+
 DATASET_DETAILS_QUERY = """
 query getDatasetDetails($id: ID!) {
     allDataset(id: $id, first: 1) {
         edges {
             node {
                 id
-                name
-                description
+                namePt
+                nameEn
+                nameEs
+                descriptionPt
+                descriptionEn
+                descriptionEs
                 organizations {
                     edges {
                         node {
-                            name
+                            namePt
+                            nameEn
+                            nameEs
                         }
                     }
                 }
                 themes {
                     edges {
                         node {
-                            name
+                            namePt
+                            nameEn
+                            nameEs
                         }
                     }
                 }
                 tags {
                     edges {
                         node {
-                            name
+                            namePt
+                            nameEn
+                            nameEs
                         }
                     }
                 }
@@ -31,8 +47,12 @@ query getDatasetDetails($id: ID!) {
                     edges {
                         node {
                             id
-                            name
-                            description
+                            namePt
+                            nameEn
+                            nameEs
+                            descriptionPt
+                            descriptionEn
+                            descriptionEs
                             temporalCoverage
                             cloudTables {
                                 edges {
@@ -58,8 +78,12 @@ query getTableDetails($id: ID!) {
         edges {
             node {
                 id
-                name
-                description
+                namePt
+                nameEn
+                nameEs
+                descriptionPt
+                descriptionEn
+                descriptionEs
                 temporalCoverage
                 cloudTables {
                     edges {
@@ -75,7 +99,9 @@ query getTableDetails($id: ID!) {
                         node {
                             id
                             name
-                            description
+                            descriptionPt
+                            descriptionEn
+                            descriptionEs
                             measurementUnit
                             coveredByDictionary
                             isPartition

--- a/app/api/streaming/agent_runner.py
+++ b/app/api/streaming/agent_runner.py
@@ -275,9 +275,10 @@ async def run_agent(
                     collected_handles,
                 )
             elif event.type == "final_answer":
-                # Resolve data source names to {dataset_name}—{table_name}
+                # Resolve data source names to {dataset_name}—{table_name},
+                # localized to the thread's language (falls back to pt).
                 if event.data.structured_response is not None:
-                    await resolve_data_source_names(event.data.structured_response)
+                    await resolve_data_source_names(event.data.structured_response, language)
                 structured_response = event.data.structured_response
                 # Set the assistant message
                 assistant_message = event.data.content

--- a/app/api/streaming/data_sources.py
+++ b/app/api/streaming/data_sources.py
@@ -5,17 +5,24 @@ from typing import Any
 import httpx
 from loguru import logger
 
+from app.i18n import DEFAULT_LANGUAGE, normalize_language
 from app.settings import settings
 
-# Minimal GraphQL query to resolve a table's name and its dataset's name from the table UUID.
+# Minimal GraphQL query to resolve a table's name and its dataset's name from the
+# table UUID. The localized name fields (modeltranslation) are fetched alongside
+# the default pt `name` so the display name can match the thread's language.
 TABLE_NAME_QUERY = """
 query getTableName($id: ID!) {
     allTable(id: $id, first: 1) {
         edges {
             node {
                 name
+                nameEn
+                nameEs
                 dataset {
                     name
+                    nameEn
+                    nameEs
                 }
             }
         }
@@ -26,23 +33,44 @@ query getTableName($id: ID!) {
 # Base dos Dados GraphQL endpoint, used to resolve data source display names.
 _GRAPHQL_URL = f"{settings.BASEDOSDADOS_BASE_URL}/graphql"
 
-# Dedicated HTTP client + cache for resolving data source display names from table UUIDs.
+# Dedicated HTTP client + cache for resolving data source display names from table
+# UUIDs. The cache is keyed by (language, table_id) because the resolved name is
+# localized — the same table has a different display name per language.
 _http_client = httpx.AsyncClient(timeout=httpx.Timeout(5.0, read=60.0))
-_TABLE_NAME_CACHE: dict[str, str] = {}
+_TABLE_NAME_CACHE: dict[tuple[str, str], str] = {}
 
 
-async def _resolve_table_name(table_id: str) -> str | None:
-    """Resolve a table UUID to a human-readable "{dataset_name} — {table_name}" and caches results.
+def _pick_localized_name(node: dict, language: str) -> str | None:
+    """Pick a node's display name for `language`, falling back to the pt `name`.
+
+    Args:
+        node (dict): A GraphQL node exposing `name` (pt) plus `nameEn`/`nameEs`.
+        language (str): One of "pt", "en", "es".
+
+    Returns:
+        str | None: The localized name, the pt `name` when the localized field is
+            empty (coverage is partial), or None if the node has no name at all.
+    """
+    localized = {"en": node.get("nameEn"), "es": node.get("nameEs")}.get(language)
+    return localized or node.get("name")
+
+
+async def _resolve_table_name(table_id: str, language: str) -> str | None:
+    """Resolve a table UUID to a human-readable "{dataset_name} — {table_name}",
+    localized to `language`, and cache results per (language, table_id).
 
     Args:
         table_id (str): A Table UUID.
+        language (str): The thread's language ("pt", "en", "es"); the resolved
+            name uses the matching localized fields, falling back to pt.
 
     Returns:
         str | None: "{dataset_name} — {table_name}", or None if the table can't
             be resolved (unknown UUID, missing names, network error, etc.).
     """
-    if table_id in _TABLE_NAME_CACHE:
-        return _TABLE_NAME_CACHE[table_id]
+    cache_key = (language, table_id)
+    if cache_key in _TABLE_NAME_CACHE:
+        return _TABLE_NAME_CACHE[cache_key]
 
     try:
         response = await _http_client.post(
@@ -62,20 +90,23 @@ async def _resolve_table_name(table_id: str) -> str | None:
         return None
 
     node = edges[0]["node"]
-    table_name = node.get("name")
-    dataset_name = (node.get("dataset") or {}).get("name")
+    table_name = _pick_localized_name(node, language)
+    dataset_name = _pick_localized_name(node.get("dataset") or {}, language)
 
     if not table_name or not dataset_name:
         return None
 
     name = f"{dataset_name} — {table_name}"
-    _TABLE_NAME_CACHE[table_id] = name
+    _TABLE_NAME_CACHE[cache_key] = name
     return name
 
 
-async def resolve_data_source_names(structured_response: dict[str, Any]) -> None:
+async def resolve_data_source_names(
+    structured_response: dict[str, Any], language: str = DEFAULT_LANGUAGE
+) -> None:
     """Overwrite each data source's display name with a deterministic
-    "{dataset_name} — {table_name}" resolved from its table UUID.
+    "{dataset_name} — {table_name}" resolved from its table UUID, localized to
+    `language` (falling back to the pt name where a translation is missing).
 
     The resolved name is authoritative; the model-provided `name` (see
     `app.agent.schemas.DataSource`) is kept as a fallback for any source whose
@@ -85,7 +116,9 @@ async def resolve_data_source_names(structured_response: dict[str, Any]) -> None
     Args:
         structured_response (dict[str, Any]): The dumped StructuredResponse whose
             `data_sources` entries are enriched in place.
+        language (str): The thread's language; selects the localized name fields.
     """
+    language = normalize_language(language)
     data_sources = structured_response.get("data_sources") or []
     resolvable = [source for source in data_sources if source["table_id"]]
 
@@ -93,7 +126,7 @@ async def resolve_data_source_names(structured_response: dict[str, Any]) -> None
         return
 
     names = await asyncio.gather(
-        *(_resolve_table_name(source["table_id"]) for source in resolvable),
+        *(_resolve_table_name(source["table_id"], language) for source in resolvable),
         return_exceptions=True,
     )
 

--- a/app/api/streaming/data_sources.py
+++ b/app/api/streaming/data_sources.py
@@ -5,22 +5,24 @@ from typing import Any
 import httpx
 from loguru import logger
 
-from app.i18n import DEFAULT_LANGUAGE, normalize_language
+from app.i18n import DEFAULT_LANGUAGE, localized_field, normalize_language
 from app.settings import settings
 
 # Minimal GraphQL query to resolve a table's name and its dataset's name from the
-# table UUID. The localized name fields (modeltranslation) are fetched alongside
-# the default pt `name` so the display name can match the thread's language.
+# table UUID. All three explicit modeltranslation columns are fetched so the
+# display name can match the thread's language; `namePt` is the pt fallback.
+# (The unqualified `name` accessor is deliberately avoided: it returns the
+# server's active-language value, which is ambiguous for a headless request.)
 TABLE_NAME_QUERY = """
 query getTableName($id: ID!) {
     allTable(id: $id, first: 1) {
         edges {
             node {
-                name
+                namePt
                 nameEn
                 nameEs
                 dataset {
-                    name
+                    namePt
                     nameEn
                     nameEs
                 }
@@ -38,21 +40,6 @@ _GRAPHQL_URL = f"{settings.BASEDOSDADOS_BASE_URL}/graphql"
 # localized — the same table has a different display name per language.
 _http_client = httpx.AsyncClient(timeout=httpx.Timeout(5.0, read=60.0))
 _TABLE_NAME_CACHE: dict[tuple[str, str], str] = {}
-
-
-def _pick_localized_name(node: dict, language: str) -> str | None:
-    """Pick a node's display name for `language`, falling back to the pt `name`.
-
-    Args:
-        node (dict): A GraphQL node exposing `name` (pt) plus `nameEn`/`nameEs`.
-        language (str): One of "pt", "en", "es".
-
-    Returns:
-        str | None: The localized name, the pt `name` when the localized field is
-            empty (coverage is partial), or None if the node has no name at all.
-    """
-    localized = {"en": node.get("nameEn"), "es": node.get("nameEs")}.get(language)
-    return localized or node.get("name")
 
 
 async def _resolve_table_name(table_id: str, language: str) -> str | None:
@@ -90,8 +77,8 @@ async def _resolve_table_name(table_id: str, language: str) -> str | None:
         return None
 
     node = edges[0]["node"]
-    table_name = _pick_localized_name(node, language)
-    dataset_name = _pick_localized_name(node.get("dataset") or {}, language)
+    table_name = localized_field(node, "name", language)
+    dataset_name = localized_field(node.get("dataset") or {}, "name", language)
 
     if not table_name or not dataset_name:
         return None

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -129,3 +129,29 @@ def t(key: str, language: str) -> str:
         str: The localized string.
     """
     return _MESSAGES[key][normalize_language(language)]
+
+
+# GraphQL modeltranslation columns are exposed as `{field}Pt`/`{field}En`/`{field}Es`.
+_LANG_FIELD_SUFFIX: dict[str, str] = {"pt": "Pt", "en": "En", "es": "Es"}
+
+
+def localized_field(node: dict, field: str, language: str) -> str | None:
+    """Pick a GraphQL node's localized `field` for `language`, pt as fallback.
+
+    modeltranslation exposes per-language columns as `{field}Pt`/`{field}En`/
+    `{field}Es` (e.g. `name` -> `namePt`/`nameEn`/`nameEs`, `description` ->
+    `descriptionPt`/...). The unqualified accessor (`name`) is deliberately not
+    used: it returns the server's active-language value, ambiguous for a
+    headless request.
+
+    Args:
+        node (dict): A GraphQL node exposing the modeltranslation columns.
+        field (str): The base field name, e.g. "name" or "description".
+        language (str): A language code; unsupported values fall back to default.
+
+    Returns:
+        str | None: The requested language's value, the pt value when it is empty
+            (coverage is partial), or None when neither is set.
+    """
+    suffix = _LANG_FIELD_SUFFIX[normalize_language(language)]
+    return node.get(f"{field}{suffix}") or node.get(f"{field}Pt")

--- a/tests/app/agent/tools/test_api.py
+++ b/tests/app/agent/tools/test_api.py
@@ -21,6 +21,9 @@ class TestSearchDatasets:
     @respx.mock
     async def test_search_datasets_returns_overviews(self):
         """Test successful dataset search."""
+        # The /search/ endpoint is locale-aware server-side, so the response
+        # already carries name/description/tags/themes/organizations in the
+        # requested locale — the tool reads them verbatim.
         mock_response = {
             "results": [
                 {
@@ -79,13 +82,13 @@ class TestGetDatasetDetails:
                         {
                             "node": {
                                 "id": "DatasetNode:dataset-1",
-                                "name": "Test Dataset",
-                                "description": "Dataset description",
-                                "tags": {"edges": [{"node": {"name": "tag1"}}]},
-                                "themes": {"edges": [{"node": {"name": "theme1"}}]},
+                                "namePt": "Test Dataset",
+                                "descriptionPt": "Dataset description",
+                                "tags": {"edges": [{"node": {"namePt": "tag1"}}]},
+                                "themes": {"edges": [{"node": {"namePt": "theme1"}}]},
                                 "organizations": {
                                     "edges": [
-                                        {"node": {"name": "org1", "slug": "org1_slug"}}
+                                        {"node": {"namePt": "org1", "slug": "org1_slug"}}
                                     ]
                                 },
                                 "tables": {
@@ -93,8 +96,8 @@ class TestGetDatasetDetails:
                                         {
                                             "node": {
                                                 "id": "TableNode:table-1",
-                                                "name": "Test Table",
-                                                "description": "Table description",
+                                                "namePt": "Test Table",
+                                                "descriptionPt": "Table description",
                                                 "temporalCoverage": {
                                                     "start": "2020",
                                                     "end": "2023",
@@ -180,8 +183,8 @@ class TestGetDatasetDetails:
                         {
                             "node": {
                                 "id": "dataset-1",
-                                "name": "Test Dataset",
-                                "description": "Dataset description",
+                                "namePt": "Test Dataset",
+                                "descriptionPt": "Dataset description",
                                 "tags": {"edges": [{"node": {}}]},
                                 "themes": {"edges": [{"node": {}}]},
                                 "organizations": {"edges": [{"node": {}}]},
@@ -190,8 +193,8 @@ class TestGetDatasetDetails:
                                         {
                                             "node": {
                                                 "id": "table-1",
-                                                "name": "Test Table",
-                                                "description": "Table description",
+                                                "namePt": "Test Table",
+                                                "descriptionPt": "Table description",
                                                 "temporalCoverage": {
                                                     "start": "2020",
                                                     "end": "2023",
@@ -243,14 +246,14 @@ class TestGetDatasetDetails:
                         {
                             "node": {
                                 "id": "dataset-1",
-                                "name": "Test Dataset",
+                                "namePt": "Test Dataset",
                                 "slug": "test_dataset",
-                                "description": "Dataset description",
-                                "tags": {"edges": [{"node": {"name": "tag1"}}]},
-                                "themes": {"edges": [{"node": {"name": "theme1"}}]},
+                                "descriptionPt": "Dataset description",
+                                "tags": {"edges": [{"node": {"namePt": "tag1"}}]},
+                                "themes": {"edges": [{"node": {"namePt": "theme1"}}]},
                                 "organizations": {
                                     "edges": [
-                                        {"node": {"name": "org1", "slug": "org1_slug"}}
+                                        {"node": {"namePt": "org1", "slug": "org1_slug"}}
                                     ]
                                 },
                                 "tables": {
@@ -258,9 +261,9 @@ class TestGetDatasetDetails:
                                         {
                                             "node": {
                                                 "id": "table-1",
-                                                "name": "Test Table",
+                                                "namePt": "Test Table",
                                                 "slug": "test_table",
-                                                "description": "Table description",
+                                                "descriptionPt": "Table description",
                                                 "temporalCoverage": {
                                                     "start": "2020",
                                                     "end": "2023",
@@ -320,8 +323,8 @@ class TestGetTableDetails:
                         {
                             "node": {
                                 "id": "TableNode:table-1",
-                                "name": "Test Table",
-                                "description": "Table description",
+                                "namePt": "Test Table",
+                                "descriptionPt": "Table description",
                                 "temporalCoverage": {
                                     "start": "2020",
                                     "end": "2023",
@@ -343,7 +346,7 @@ class TestGetTableDetails:
                                             "node": {
                                                 "id": "col-1",
                                                 "name": "peso_liquido",
-                                                "description": "Peso líquido",
+                                                "descriptionPt": "Peso líquido",
                                                 "measurementUnit": "kg",
                                                 "coveredByDictionary": False,
                                                 "isPartition": False,
@@ -355,7 +358,7 @@ class TestGetTableDetails:
                                             "node": {
                                                 "id": "col-2",
                                                 "name": "status",
-                                                "description": "Status",
+                                                "descriptionPt": "Status",
                                                 "measurementUnit": None,
                                                 "coveredByDictionary": True,
                                                 "isPartition": False,
@@ -367,7 +370,7 @@ class TestGetTableDetails:
                                             "node": {
                                                 "id": "col-3",
                                                 "name": "id_municipio",
-                                                "description": "ID do município",
+                                                "descriptionPt": "ID do município",
                                                 "measurementUnit": None,
                                                 "coveredByDictionary": False,
                                                 "isPartition": False,
@@ -393,7 +396,7 @@ class TestGetTableDetails:
                                             "node": {
                                                 "id": "col-4",
                                                 "name": "ano",
-                                                "description": "Ano",
+                                                "descriptionPt": "Ano",
                                                 "measurementUnit": None,
                                                 "coveredByDictionary": False,
                                                 "isPartition": True,

--- a/tests/app/api/streaming/test_agent_runner.py
+++ b/tests/app/api/streaming/test_agent_runner.py
@@ -692,7 +692,7 @@ class TestRunAgent:
             follow_up_questions=["E em 2026?"],
         )
 
-        async def fake_resolve(structured_response: dict[str, Any]):
+        async def fake_resolve(structured_response: dict[str, Any], language: str):
             for source in structured_response.get("data_sources") or []:
                 source["name"] = "Conjunto DS1 - Tabela TB1"
 

--- a/tests/app/api/streaming/test_data_sources.py
+++ b/tests/app/api/streaming/test_data_sources.py
@@ -24,7 +24,7 @@ class TestResolveTableName:
 
     @staticmethod
     def _node_response(dataset_name: str | None, table_name: str | None):
-        node = {"name": table_name, "dataset": {"name": dataset_name}}
+        node = {"namePt": table_name, "dataset": {"namePt": dataset_name}}
         return {"data": {"allTable": {"edges": [{"node": node}]}}}
 
     @respx.mock
@@ -36,7 +36,7 @@ class TestResolveTableName:
             )
         )
 
-        assert await _resolve_table_name("tb1") == "Diretórios Brasileiros — Município"
+        assert await _resolve_table_name("tb1", "pt") == "Diretórios Brasileiros — Município"
 
     @respx.mock
     async def test_caches_successful_resolution(self):
@@ -47,8 +47,8 @@ class TestResolveTableName:
             )
         )
 
-        first = await _resolve_table_name("tb1")
-        second = await _resolve_table_name("tb1")
+        first = await _resolve_table_name("tb1", "pt")
+        second = await _resolve_table_name("tb1", "pt")
 
         assert first == second == "Diretórios Brasileiros — Município"
         assert route.call_count == 1
@@ -60,8 +60,8 @@ class TestResolveTableName:
             return_value=httpx.Response(200, json={"data": {"allTable": {"edges": []}}})
         )
 
-        assert await _resolve_table_name("missing") is None
-        assert "missing" not in _TABLE_NAME_CACHE
+        assert await _resolve_table_name("missing", "pt") is None
+        assert ("pt", "missing") not in _TABLE_NAME_CACHE
 
     @respx.mock
     async def test_returns_none_on_missing_dataset_name(self):
@@ -72,7 +72,7 @@ class TestResolveTableName:
             )
         )
 
-        assert await _resolve_table_name("tb1") is None
+        assert await _resolve_table_name("tb1", "pt") is None
 
     @respx.mock
     async def test_returns_none_on_missing_table_name(self):
@@ -83,14 +83,14 @@ class TestResolveTableName:
             )
         )
 
-        assert await _resolve_table_name("tb1") is None
+        assert await _resolve_table_name("tb1", "pt") is None
 
     @respx.mock
     async def test_returns_none_on_http_error(self):
         """A backend error is swallowed and resolves to None."""
         respx.post(_GRAPHQL_URL).mock(return_value=httpx.Response(500))
 
-        assert await _resolve_table_name("tb1") is None
+        assert await _resolve_table_name("tb1", "pt") is None
 
     @respx.mock
     async def test_returns_none_on_json_decode_error(self):
@@ -101,7 +101,7 @@ class TestResolveTableName:
             return_value=httpx.Response(200, content=b"{'malformed': 'json'")
         )
 
-        assert await _resolve_table_name("tb1") is None
+        assert await _resolve_table_name("tb1", "pt") is None
 
 
 class TestResolveDataSourceNames:
@@ -111,7 +111,7 @@ class TestResolveDataSourceNames:
         self, monkeypatch: pytest.MonkeyPatch
     ):
         """A successful resolution overwrites the model-provided fallback name."""
-        resolve_name = AsyncMock(side_effect=lambda tid: f"Conjunto - {tid}")
+        resolve_name = AsyncMock(side_effect=lambda tid, language: f"Conjunto - {tid}")
 
         monkeypatch.setattr(
             "app.api.streaming.data_sources._resolve_table_name", resolve_name


### PR DESCRIPTION
Localizes the chatbot's data metadata — both what the user sees and what the agent grounds on — to the thread's language, with a pt fallback everywhere. Complements #58, which already made the bot *answer* in the site language and persists `Thread.language`; this PR closes the metadata side, which was still Portuguese-only.

## What was wrong
The agent read and displayed dataset/table metadata in Portuguese regardless of the thread language:
- The "Fontes dos Dados" source names resolved via a GraphQL lookup that fetched only the pt `name`.
- The retrieval tools (`search_datasets`, `get_dataset_details`, `get_table_details`) read pt-only `name`/`description`, so the model grounded on — and often echoed — Portuguese names, descriptions, themes, tags, organizations, and usage guides.

## What changed
**Display — source names** (`app/api/streaming/data_sources.py`)
- Resolve `namePt`/`nameEn`/`nameEs` and pick by the thread's language (pt fallback where a translation is missing); cache keyed by `(language, table_id)`.

**Grounding — retrieval tools** (`app/agent/tools/`)
- `search_datasets` passes `locale` to the `/search/` endpoint, which is already locale-aware (it matches the localized text field and returns `dataset_name_{locale}`/`dataset_description_{locale}` plus localized themes/tags/organizations, all with server-side pt fallback).
- `get_dataset_details` fetches the explicit `namePt/nameEn/nameEs` + `descriptionPt/...` columns and picks by language for the dataset **and its tables**; **themes, tags, and organizations** are localized too, and the **usage guide** is fetched from `userGuide/{locale}/` with a pt fallback (only pt guides exist today).
- `get_table_details` localizes the table name/description and **column descriptions** (column *names* stay — they are real BigQuery identifiers).

**Plumbing**
- New shared helper `app.i18n.localized_field(node, field, language)` (used by both the resolver and the tools).
- Language reaches the tools via injected `RunnableConfig` (`config["configurable"]["language"]`, set alongside `thread_id` when the run is dispatched) — the same pattern `execute_bigquery_sql` already uses, so the model never sees the `config` argument.

## Deliberately left Portuguese
- **Column identifiers** — real BigQuery column names (`municipio`, `ano`, …).
- The Brazil-specific **few-shot examples** in `app/agent/prompts.py` (not user-visible; steer the model).

## Coverage / fallback
Every path falls back to pt when a localized value is empty. On a 100-table sample: ~91% have `nameEn`, ~89% `nameEs`; descriptions and en/es usage guides are lower and fall back to pt.

## Verification
- `python -m py_compile` clean on all changed files.
- Verified live that `TableNode`/`DatasetNode`/`ColumnNode`/`OrganizationNode`/`ThemeNode`/`TagNode` expose the `nameEn/Es` + `descriptionEn/Es` columns, and that the `/search/` endpoint localizes results (`locale=en` → *"American Time Use Survey (ATUS)"* / theme *"Economy"* vs pt *"Pesquisa Americana de Uso do Tempo (ATUS)"* / *"Economia"*).
- Could not run the full app locally (no env) — CI is the build + tool-schema gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
