### PR TITLE
refactor: thread language locale

### DIFF
--- a/alembic/versions/4b3d2fa4a75f_add_thread_language.py
+++ b/alembic/versions/4b3d2fa4a75f_add_thread_language.py
@@ -19,8 +19,8 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     """Upgrade schema."""
-    # server_default backfills existing threads with the Portuguese default; new rows get
-    # their value from the application (ThreadPayload.language).
+    # server_default backfills existing threads with the Portuguese default;
+    # new rows get their value from the application (ThreadPayload.language).
     op.add_column(
         "thread",
         sa.Column("language", sa.String(), nullable=False, server_default="pt"),

--- a/app/agent/context.py
+++ b/app/agent/context.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+
+from app.i18n import LanguageCode
+
+
+@dataclass
+class AgentContext:
+    """Per-run context for an agent run.
+
+    Read by:
+      - The system-prompt middleware (`language`)
+      - The tools (`language` for localized metadata; `thread_id` and `user_id` for BigQuery job labels).
+
+    `thread_id` is *also* kept in `config["configurable"]` because the langgraph
+    checkpointer keys persistence on it there; on this context it is app metadata.
+    """
+
+    thread_id: str
+    user_id: str
+    language: LanguageCode

--- a/app/agent/middleware.py
+++ b/app/agent/middleware.py
@@ -1,0 +1,17 @@
+from datetime import date
+
+from langchain.agents.middleware import ModelRequest, dynamic_prompt
+
+from app.agent.context import AgentContext
+from app.i18n import language_directive
+
+
+@dynamic_prompt
+def system_prompt_middleware(request: ModelRequest) -> str:
+    """Render the system prompt template, filling `{current_date}` and `{language_directive}`."""
+    context: AgentContext = request.runtime.context
+
+    return request.system_message.content.format(
+        current_date=date.today().isoformat(),
+        language_directive=language_directive(context.language),
+    )

--- a/app/agent/prompts.py
+++ b/app/agent/prompts.py
@@ -131,7 +131,7 @@ Fill them **only** based on the tool results obtained in this conversation:
 - Do **NOT** use Markdown headers (# or ##) or section titles in the response.
 - Use only flowing text, bold for emphasis, lists, tables, and code blocks.
 - Keep a professional yet accessible tone.
-- Always respond in the user's language.
+- {language_directive}
 
 ---
 

--- a/app/agent/tools/api.py
+++ b/app/agent/tools/api.py
@@ -1,9 +1,10 @@
 import json
 
 import httpx
-from langchain_core.runnables import RunnableConfig
+from langchain.tools import ToolRuntime
 from langchain_core.tools import tool
 
+from app.agent.context import AgentContext
 from app.agent.tools.exceptions import handle_tool_errors
 from app.agent.tools.models import (
     Column,
@@ -13,7 +14,7 @@ from app.agent.tools.models import (
     TableOverview,
 )
 from app.agent.tools.queries import DATASET_DETAILS_QUERY, TABLE_DETAILS_QUERY
-from app.i18n import localized_field, normalize_language
+from app.i18n import DEFAULT_LANGUAGE, LanguageCode, localized_field
 from app.settings import settings
 
 # httpx default timeout
@@ -41,42 +42,36 @@ BASE_USAGE_GUIDE_URL = "https://raw.githubusercontent.com/basedosdados/website/r
 _client = httpx.AsyncClient(timeout=httpx.Timeout(TIMEOUT, read=READ_TIMEOUT))
 
 
-def _config_language(config: RunnableConfig) -> str:
-    """Read the thread's language from the injected run config (pt default).
+async def _fetch_usage_guide(gcp_dataset_id: str, language: LanguageCode) -> str | None:
+    """Fetch a dataset's usage-guide markdown for `language`, falling back to the default.
 
-    The language is set on `config["configurable"]["language"]` when the agent
-    run is dispatched (see the chatbot router). LangChain injects the run config
-    into any tool that declares a `RunnableConfig` parameter, without exposing it
-    to the model, so the tools can localize the metadata they return.
-    """
-    return normalize_language((config.get("configurable") or {}).get("language"))
-
-
-async def _fetch_usage_guide(gcp_dataset_id: str, language: str) -> str | None:
-    """Fetch a dataset's usage-guide markdown for `language`, falling back to pt.
-
-    Localized guides may not exist yet (only pt is populated today), so a missing
-    localized file falls back to the pt guide.
+    Localized guides may not exist yet (only the default language is populated today), so
+    a missing localized file falls back to the default-language guide.
 
     Args:
-        gcp_dataset_id (str): The BigQuery dataset id (its dashes form the filename).
-        language (str): The thread's language ("pt", "en", "es").
+        gcp_dataset_id (str): The BigQuery dataset id.
+        language (LanguageCode): The thread's language.
 
     Returns:
         str | None: The guide markdown, or None if no guide exists in any language.
     """
     filename = gcp_dataset_id.replace("_", "-")
-    locales = ["pt"] if language == "pt" else [language, "pt"]
+
+    # Try the requested language, then the default; `fromkeys` preserves order
+    # and drops the duplicate when `language` is already the default.
+    locales = dict.fromkeys((language, DEFAULT_LANGUAGE))
+
     for locale in locales:
         response = await _client.get(f"{BASE_USAGE_GUIDE_URL}/{locale}/{filename}.md")
         if response.status_code == httpx.codes.OK:
             return response.text.strip()
+
     return None
 
 
 @tool
 @handle_tool_errors
-async def search_datasets(query: str, config: RunnableConfig) -> str:
+async def search_datasets(query: str, runtime: ToolRuntime[AgentContext]) -> str:
     """Search for datasets in Base dos Dados using keywords.
 
     CRITICAL: Use individual KEYWORDS only, not full sentences. The search engine uses Elasticsearch.
@@ -97,18 +92,13 @@ async def search_datasets(query: str, config: RunnableConfig) -> str:
 
     Next step: Use `get_dataset_details()` with returned dataset IDs.
     """
-    # The /search/ endpoint is locale-aware: it matches the localized text field
-    # and returns name/description/themes/tags/organizations in `locale`, each
-    # falling back to pt server-side.
-    language = _config_language(config)
-
     response = await _client.get(
         url=SEARCH_URL,
         params={
             "contains": "tables",
             "q": query,
             "page_size": PAGE_SIZE,
-            "locale": language,
+            "locale": runtime.context.language,
         },
     )
 
@@ -135,7 +125,9 @@ async def search_datasets(query: str, config: RunnableConfig) -> str:
 
 @tool
 @handle_tool_errors
-async def get_dataset_details(dataset_id: str, config: RunnableConfig) -> str:
+async def get_dataset_details(
+    dataset_id: str, runtime: ToolRuntime[AgentContext]
+) -> str:
     """Get comprehensive details about a specific dataset including all its tables.
 
     Use AFTER `search_datasets()` to understand data structure before writing queries.
@@ -175,7 +167,7 @@ async def get_dataset_details(dataset_id: str, config: RunnableConfig) -> str:
 
     dataset = dataset_edges[0]["node"]
 
-    language = _config_language(config)
+    language = runtime.context.language
 
     dataset_id = dataset["id"].split("DatasetNode:")[-1]
     dataset_name = localized_field(dataset, "name", language)
@@ -255,7 +247,7 @@ async def get_dataset_details(dataset_id: str, config: RunnableConfig) -> str:
 
 @tool
 @handle_tool_errors
-async def get_table_details(table_id: str, config: RunnableConfig) -> str:
+async def get_table_details(table_id: str, runtime: ToolRuntime[AgentContext]) -> str:
     """Get comprehensive details about a specific table including all its columns.
 
     Use AFTER `get_dataset_details()` to understand table structure before writing queries.
@@ -296,7 +288,7 @@ async def get_table_details(table_id: str, config: RunnableConfig) -> str:
 
     table = table_edges[0]["node"]
 
-    language = _config_language(config)
+    language = runtime.context.language
 
     table_id = table["id"].split("TableNode:")[-1]
     table_name = localized_field(table, "name", language)

--- a/app/agent/tools/bigquery.py
+++ b/app/agent/tools/bigquery.py
@@ -6,9 +6,10 @@ from typing import Any
 
 from google.api_core.exceptions import GoogleAPICallError, NotFound
 from google.cloud import bigquery as bq
-from langchain_core.runnables import RunnableConfig
+from langchain.tools import ToolRuntime
 from langchain_core.tools import tool
 
+from app.agent.context import AgentContext
 from app.agent.tools.exceptions import handle_tool_errors
 from app.settings import settings
 
@@ -26,7 +27,7 @@ def _bq_client() -> bq.Client:  # pragma: no cover
 @tool(response_format="content_and_artifact")
 @handle_tool_errors(response_format="content_and_artifact")
 def execute_bigquery_sql(
-    sql_query: str, slug: str, config: RunnableConfig
+    sql_query: str, slug: str, runtime: ToolRuntime[AgentContext]
 ) -> tuple[str, dict[str, Any] | None]:
     """Execute a SQL query against BigQuery tables from the Base dos Dados database.
 
@@ -69,8 +70,8 @@ def execute_bigquery_sql(
         )
 
     labels = {
-        "thread_id": config.get("configurable", {}).get("thread_id", "unknown"),
-        "user_id": config.get("configurable", {}).get("user_id", "unknown"),
+        "thread_id": runtime.context.thread_id,
+        "user_id": runtime.context.user_id,
         "tool_name": inspect.currentframe().f_code.co_name,
     }
 
@@ -118,7 +119,9 @@ def execute_bigquery_sql(
 @tool
 @handle_tool_errors
 def decode_table_values(
-    table_gcp_id: str, config: RunnableConfig, column_name: str | None = None
+    table_gcp_id: str,
+    runtime: ToolRuntime[AgentContext],
+    column_name: str | None = None,
 ) -> str:
     """Fetch the dictionary mapping (code -> human-readable value) for a coded column.
 
@@ -167,8 +170,8 @@ def decode_table_values(
     search_query += "ORDER BY nome_coluna, chave"
 
     labels = {
-        "thread_id": config.get("configurable", {}).get("thread_id", "unknown"),
-        "user_id": config.get("configurable", {}).get("user_id", "unknown"),
+        "thread_id": runtime.context.thread_id,
+        "user_id": runtime.context.user_id,
         "tool_name": inspect.currentframe().f_code.co_name,
     }
 

--- a/app/agent/tools/queries.py
+++ b/app/agent/tools/queries.py
@@ -1,8 +1,6 @@
-# GraphQL queries fetch the explicit modeltranslation columns
-# (`namePt`/`nameEn`/`nameEs`, `descriptionPt`/...) rather than the unqualified
-# `name`/`description` accessors, so the caller can select the thread's language
-# with a pt fallback (see `app.i18n.localized_field`). Column *names* stay as the
-# real BigQuery identifiers and are never localized.
+# GraphQL queries fetch the explicit model translation columns (`namePt`/..., `descriptionPt`/...)
+# rather than the unqualified `name`/`description` accessors, so the caller can select the thread's
+# language with a pt fallback. Column names stay as the real BigQuery identifiers and are never localized.
 
 DATASET_DETAILS_QUERY = """
 query getDatasetDetails($id: ID!) {

--- a/app/api/routers/chatbot.py
+++ b/app/api/routers/chatbot.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, BackgroundTasks, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
 from loguru import logger
 
+from app.agent.context import AgentContext
 from app.api.dependencies import Agent, AsyncDB, FeedbackSender, RunningRuns, UserID
 from app.api.schemas import ConfigDict, UserMessage
 from app.api.streaming import run_agent, stream_events
@@ -30,7 +31,7 @@ from app.exports import (
     ResultTooLarge,
     materialize_export,
 )
-from app.i18n import DEFAULT_LANGUAGE, t
+from app.i18n import MessageKey, translate
 from app.settings import settings
 from app.storage import generate_signed_url
 
@@ -66,8 +67,8 @@ async def _authorize_thread(
 
 async def _authorize_message(
     database: AsyncDatabase, message_id: str, user_id: str
-) -> Message:
-    """Fetch a message and verify the caller owns the thread it belongs to.
+) -> tuple[Message, Thread]:
+    """Fetch a message and its thread, verifying the caller owns the thread.
 
     Args:
         database (AsyncDatabase): The database repository.
@@ -75,7 +76,8 @@ async def _authorize_message(
         user_id (str): The authenticated caller.
 
     Returns:
-        Message: The message, whose thread is guaranteed to belong to `user_id`.
+        tuple[Message, Thread]: The message and its owning thread,
+            guaranteed to belong to `user_id`.
 
     Raises:
         HTTPException: 404 whether the message is missing or the caller doesn't own its thread.
@@ -91,7 +93,7 @@ async def _authorize_message(
             detail=f"Message {message_id} not found",
         )
 
-    return message
+    return message, thread
 
 
 @router.get("/threads")
@@ -175,13 +177,18 @@ async def send_message(
 
     run_id = str(uuid.uuid4())
 
+    # thread_id stays in `configurable` too because the
+    # langgraph checkpointer keys persistence on it;
     config = ConfigDict(
         run_id=run_id,
-        configurable={
-            "thread_id": thread_id,
-            "user_id": user_id,
-            "language": thread.language,
-        },
+        configurable={"thread_id": thread_id},
+    )
+
+    # application data rides on the context.
+    context = AgentContext(
+        thread_id=thread_id,
+        user_id=user_id,
+        language=thread.language,
     )
 
     message_create = MessageCreate(
@@ -199,10 +206,10 @@ async def send_message(
         run_agent(
             agent=agent,
             config=config,
+            context=context,
             thread_id=thread_id,
             user_message=message,
             model_uri=settings.MODEL_URI,
-            language=thread.language,
             queue=queue,
         ),
         name=f"run_agent:{run_id}",
@@ -258,12 +265,7 @@ async def export_message_results(
             ),
         )
 
-    message = await _authorize_message(database, message_id, user_id)
-
-    # The thread's language localizes the download-failure details below. _authorize_message
-    # already validated the thread exists and is owned; re-read it to read its language.
-    thread = await database.get_thread(message.thread_id)
-    language = thread.language if thread else DEFAULT_LANGUAGE
+    message, thread = await _authorize_message(database, message_id, user_id)
 
     query_handle = await database.get_query_handle(message.id, query_ref)
 
@@ -280,19 +282,20 @@ async def export_message_results(
             destination_table=query_handle.destination_table,
             file_format=file_format,
             filename=_sanitize_filename(
-                query_handle.slug, t("default_export_filename", language)
+                query_handle.slug,
+                translate(MessageKey.DEFAULT_EXPORT_FILENAME, thread.language),
             ),
             message_id=str(message.id),
         )
     except ResultTableExpired as e:
         raise HTTPException(
             status_code=status.HTTP_410_GONE,
-            detail=t("results_expired", language),
+            detail=translate(MessageKey.RESULTS_EXPIRED, thread.language),
         ) from e
     except ResultTooLarge as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=t("results_too_large", language),
+            detail=translate(MessageKey.RESULTS_TOO_LARGE, thread.language),
         ) from e
 
     signed_url = generate_signed_url(

--- a/app/api/routers/chatbot.py
+++ b/app/api/routers/chatbot.py
@@ -177,14 +177,19 @@ async def send_message(
 
     run_id = str(uuid.uuid4())
 
-    # thread_id stays in `configurable` too because the
-    # langgraph checkpointer keys persistence on it;
+    # `configurable` carries only what the langgraph checkpointer needs (thread_id).
+    # `metadata` is what LangSmith surfaces as trace attributes, declared explicitly.
     config = ConfigDict(
         run_id=run_id,
         configurable={"thread_id": thread_id},
+        metadata={
+            "thread_id": thread_id,
+            "user_id": user_id,
+            "language": thread.language,
+        },
     )
 
-    # application data rides on the context.
+    # Application data the tools and middleware read at run time rides on the context.
     context = AgentContext(
         thread_id=thread_id,
         user_id=user_id,

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -1,4 +1,4 @@
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from pydantic import BaseModel
 
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 class ConfigDict(TypedDict):
     run_id: str
     configurable: dict[str, Any]
+    metadata: NotRequired[dict[str, Any]]
 
 
 class UserMessage(BaseModel):

--- a/app/api/streaming/agent_runner.py
+++ b/app/api/streaming/agent_runner.py
@@ -6,6 +6,7 @@ from langchain_core.messages import AIMessage, ToolMessage
 from langgraph.graph.state import CompiledStateGraph
 from loguru import logger
 
+from app.agent.context import AgentContext
 from app.agent.schemas import StructuredResponse
 from app.api.schemas import ConfigDict
 from app.api.streaming.data_sources import resolve_data_source_names
@@ -20,7 +21,7 @@ from app.db.models import (
     QueryHandle,
 )
 from app.exports import CollectedQueryHandle, collect_query_handles
-from app.i18n import DEFAULT_LANGUAGE, language_directive, t
+from app.i18n import LanguageCode, MessageKey, translate
 
 
 def _truncate_json(
@@ -81,14 +82,12 @@ def _truncate_json(
     return json.dumps(data, ensure_ascii=False, indent=2)
 
 
-def _process_chunk(
-    chunk: dict[str, Any], language: str = DEFAULT_LANGUAGE
-) -> StreamEvent | None:
+def _process_chunk(chunk: dict[str, Any], language: LanguageCode) -> StreamEvent | None:
     """Process a streaming chunk from a react agent workflow into a StreamEvent.
 
     Args:
         chunk (dict[str, Any]): A raw update chunk from the agent workflow.
-        language (str): The thread's language, for localizing server-emitted content.
+        language (LanguageCode): A supported language code, for localizing server-emitted content.
 
     Returns:
         StreamEvent | None: Structured event or None if the chunk is ignored:
@@ -183,7 +182,7 @@ def _process_chunk(
         update = chunk["ModelCallLimitMiddleware.before_model"] or {}
         if update.get("jump_to") == "end":
             event_data = EventData(
-                content=t("error_model_call_limit", language),
+                content=translate(MessageKey.ERROR_MODEL_CALL_LIMIT, language),
                 tool_calls=None,
             )
             return StreamEvent(type="model_call_limit", data=event_data)
@@ -218,11 +217,11 @@ async def _persist_query_handles(
 async def run_agent(
     agent: CompiledStateGraph,
     config: ConfigDict,
+    context: AgentContext,
     thread_id: str,
     user_message: Message,
     model_uri: str,
     queue: asyncio.Queue[StreamEvent],
-    language: str = DEFAULT_LANGUAGE,
 ):
     """Run the agent to completion and push events onto the queue.
 
@@ -234,11 +233,10 @@ async def run_agent(
     Args:
         agent (CompiledStateGraph): Agent compiled state graph.
         config (ConfigDict): Config for agent execution.
+        context (AgentContext): The run context.
         thread_id (str): Thread unique identifier.
         user_message (Message): User message.
         model_uri (str): Model URI.
-        language (str): The thread's language; sets the response-language default and
-            localizes server-emitted error messages.
         queue (asyncio.Queue[StreamEvent]): Events queue.
     """
     events = []
@@ -247,22 +245,17 @@ async def run_agent(
     collected_handles: list[CollectedQueryHandle] = []
     status: MessageStatus | None = None
 
-    # Prepend the language directive to the model input only — the persisted user Message
-    # (created by the router) keeps the user's clean text. This sets the site's language as
-    # the default while letting the model honor a user who writes in another language.
-    # A dynamic-prompt middleware would keep it out of checkpoint history entirely; see PR notes.
-    model_input = f"{language_directive(language)}\n\n{user_message.content}"
-
     try:
         async for mode, chunk in agent.astream(  # pragma: no cover
-            input={"messages": [{"role": "user", "content": model_input}]},
+            input={"messages": [{"role": "user", "content": user_message.content}]},
             config=config,
+            context=context,
             stream_mode=["updates", "values"],
         ):
             if mode == "values":
                 continue
 
-            event = _process_chunk(chunk, language)
+            event = _process_chunk(chunk, context.language)
 
             if event is None:
                 continue
@@ -275,10 +268,11 @@ async def run_agent(
                     collected_handles,
                 )
             elif event.type == "final_answer":
-                # Resolve data source names to {dataset_name}—{table_name},
-                # localized to the thread's language (falls back to pt).
+                # Resolve data source names to a localized "{dataset_name} — {table_name}".
                 if event.data.structured_response is not None:
-                    await resolve_data_source_names(event.data.structured_response, language)
+                    await resolve_data_source_names(
+                        event.data.structured_response, context.language
+                    )
                 structured_response = event.data.structured_response
                 # Set the assistant message
                 assistant_message = event.data.content
@@ -291,12 +285,14 @@ async def run_agent(
             await queue.put(event)
     except asyncio.CancelledError:
         if status is None:
-            assistant_message = t("error_interrupted", language)
+            assistant_message = translate(
+                MessageKey.ERROR_INTERRUPTED, context.language
+            )
             status = MessageStatus.INTERRUPTED
         raise
     except Exception:
         logger.exception(f"Unexpected error in run {config['run_id']}:")
-        assistant_message = t("error_unexpected", language)
+        assistant_message = translate(MessageKey.ERROR_UNEXPECTED, context.language)
         status = MessageStatus.ERROR
         event = StreamEvent(
             type="error",

--- a/app/api/streaming/data_sources.py
+++ b/app/api/streaming/data_sources.py
@@ -5,14 +5,12 @@ from typing import Any
 import httpx
 from loguru import logger
 
-from app.i18n import DEFAULT_LANGUAGE, localized_field, normalize_language
+from app.i18n import LanguageCode, localized_field
 from app.settings import settings
 
 # Minimal GraphQL query to resolve a table's name and its dataset's name from the
-# table UUID. All three explicit modeltranslation columns are fetched so the
+# table UUID. All three explicit model translation columns are fetched so the
 # display name can match the thread's language; `namePt` is the pt fallback.
-# (The unqualified `name` accessor is deliberately avoided: it returns the
-# server's active-language value, which is ambiguous for a headless request.)
 TABLE_NAME_QUERY = """
 query getTableName($id: ID!) {
     allTable(id: $id, first: 1) {
@@ -35,27 +33,26 @@ query getTableName($id: ID!) {
 # Base dos Dados GraphQL endpoint, used to resolve data source display names.
 _GRAPHQL_URL = f"{settings.BASEDOSDADOS_BASE_URL}/graphql"
 
-# Dedicated HTTP client + cache for resolving data source display names from table
-# UUIDs. The cache is keyed by (language, table_id) because the resolved name is
-# localized — the same table has a different display name per language.
+# Dedicated HTTP client + cache for resolving data source display names from table UUIDs.
+# The cache is keyed by (language, table_id) because the resolved name is localized.
 _http_client = httpx.AsyncClient(timeout=httpx.Timeout(5.0, read=60.0))
 _TABLE_NAME_CACHE: dict[tuple[str, str], str] = {}
 
 
-async def _resolve_table_name(table_id: str, language: str) -> str | None:
+async def _resolve_table_name(table_id: str, language: LanguageCode) -> str | None:
     """Resolve a table UUID to a human-readable "{dataset_name} — {table_name}",
     localized to `language`, and cache results per (language, table_id).
 
     Args:
         table_id (str): A Table UUID.
-        language (str): The thread's language ("pt", "en", "es"); the resolved
-            name uses the matching localized fields, falling back to pt.
+        language (LanguageCode): A supported language code.
 
     Returns:
         str | None: "{dataset_name} — {table_name}", or None if the table can't
             be resolved (unknown UUID, missing names, network error, etc.).
     """
-    cache_key = (language, table_id)
+    cache_key = (table_id, language)
+
     if cache_key in _TABLE_NAME_CACHE:
         return _TABLE_NAME_CACHE[cache_key]
 
@@ -89,11 +86,10 @@ async def _resolve_table_name(table_id: str, language: str) -> str | None:
 
 
 async def resolve_data_source_names(
-    structured_response: dict[str, Any], language: str = DEFAULT_LANGUAGE
+    structured_response: dict[str, Any], language: LanguageCode
 ) -> None:
     """Overwrite each data source's display name with a deterministic
-    "{dataset_name} — {table_name}" resolved from its table UUID, localized to
-    `language` (falling back to the pt name where a translation is missing).
+    "{dataset_name} — {table_name}" resolved from its table UUID, localized to `language`.
 
     The resolved name is authoritative; the model-provided `name` (see
     `app.agent.schemas.DataSource`) is kept as a fallback for any source whose
@@ -103,9 +99,8 @@ async def resolve_data_source_names(
     Args:
         structured_response (dict[str, Any]): The dumped StructuredResponse whose
             `data_sources` entries are enriched in place.
-        language (str): The thread's language; selects the localized name fields.
+        language (LanguageCode): A supported language code.
     """
-    language = normalize_language(language)
     data_sources = structured_response.get("data_sources") or []
     resolvable = [source for source in data_sources if source["table_id"]]
 

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -5,9 +5,18 @@ from typing import Any
 
 from pydantic import JsonValue, computed_field, field_validator
 from sqlalchemy import Enum as SAEnum
-from sqlmodel import JSON, TIMESTAMP, Column, Field, Integer, Relationship, SQLModel
+from sqlmodel import (
+    JSON,
+    TIMESTAMP,
+    Column,
+    Field,
+    Integer,
+    Relationship,
+    SQLModel,
+    String,
+)
 
-from app.i18n import DEFAULT_LANGUAGE, normalize_language
+from app.i18n import DEFAULT_LANGUAGE, LanguageCode, normalize_language
 
 
 # =============================================================================
@@ -15,13 +24,11 @@ from app.i18n import DEFAULT_LANGUAGE, normalize_language
 # =============================================================================
 class ThreadPayload(SQLModel):
     title: str
-    # Captured at creation from the site's locale (pt/en/es). Steers the assistant's response
-    # language and localizes server-emitted messages. Stored as a plain code; see app.i18n.
-    language: str = Field(default=DEFAULT_LANGUAGE)
+    language: LanguageCode = Field(default=DEFAULT_LANGUAGE, sa_type=String)
 
-    @field_validator("language")
+    @field_validator("language", mode="before")
     @classmethod
-    def _normalize_language(cls, value: str) -> str:
+    def _normalize_language(cls, value: str | None) -> LanguageCode:
         return normalize_language(value)
 
 

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -1,75 +1,93 @@
-"""Localization for user-facing backend strings and per-run language steering.
-
-The chatbot serves three locales, one per Base dos Dados / Data Basis domain:
-`pt` (basedosdados.org), `en` (data-basis.org), `es` (basedelosdatos.org). A thread's
-language is captured at creation from the site the user is on (see `Thread.language`) and
-threaded into each run. The model's system prompt already asks it to answer in the user's
-language; `language_directive` gives it the site default while still honoring a user who
-writes in another language.
-
-Only strings the server itself emits live here — agent errors and download details. Agent
-answers are localized by the model, and step labels are rendered by the frontend.
-"""
-
-from typing import Literal
+from enum import StrEnum
+from typing import Literal, get_args
 
 LanguageCode = Literal["pt", "en", "es"]
 
-LANGUAGES: tuple[str, ...] = ("pt", "en", "es")
-DEFAULT_LANGUAGE: str = "pt"
+_LANGUAGES: tuple[LanguageCode, ...] = get_args(LanguageCode)
 
-# Endonyms would read better in-product, but the directive is an instruction to the model,
-# so English names keep it unambiguous regardless of the target language.
-LANGUAGE_NAMES: dict[str, str] = {
+_LANGUAGE_NAMES: dict[LanguageCode, str] = {
     "pt": "Portuguese",
     "en": "English",
     "es": "Spanish",
 }
 
+_LANGUAGE_FIELD_SUFFIX: dict[LanguageCode, str] = {
+    "pt": "Pt",
+    "en": "En",
+    "es": "Es",
+}
 
-def normalize_language(value: str | None) -> str:
+DEFAULT_LANGUAGE: LanguageCode = "pt"
+
+
+def normalize_language(value: str | None) -> LanguageCode:
     """Coerce an arbitrary language value to a supported code, falling back to the default.
 
     Args:
-        value (str | None): A raw language value (e.g. from a request or a stored row).
+        value (str | None): A raw language value from a request.
 
     Returns:
-        str: One of `LANGUAGES`.
+        LanguageCode: One of the supported language codes.
     """
     normalized = (value or DEFAULT_LANGUAGE).lower()
-    return normalized if normalized in LANGUAGES else DEFAULT_LANGUAGE
+    return normalized if normalized in _LANGUAGES else DEFAULT_LANGUAGE
 
 
-def language_directive(language: str) -> str:
-    """Build the per-run instruction that sets the site's language as the default.
-
-    "Domain default, honor the user": the model answers in the site's language unless the
-    user clearly writes in another language, in which case it matches the user.
+def localized_field(node: dict, field: str, language: LanguageCode) -> str | None:
+    """Pick a GraphQL node's localized `field` for `language`, pt as fallback.
 
     Args:
-        language (str): A supported language code (unsupported values fall back to default).
+        node (dict): A GraphQL node exposing the fields.
+        field (str): The base field name, e.g. "name" or "description".
+        language (LanguageCode): A supported language code.
 
     Returns:
-        str: A one-line directive to prepend to the user's turn.
+        str | None: The requested language's value, the pt value when it is empty
+            (coverage is partial), or None when neither is set.
     """
-    name = LANGUAGE_NAMES[normalize_language(language)]
+    suffix = _LANGUAGE_FIELD_SUFFIX[language]
+    return node.get(f"{field}{suffix}") or node.get(f"{field}Pt")
+
+
+def language_directive(language: LanguageCode) -> str:
+    """Build the instruction that sets the site's language as the response default.
+
+    Args:
+        language (LanguageCode): A supported language code.
+
+    Returns:
+        str: A one-line directive.
+    """
+    name = _LANGUAGE_NAMES[language]
+
     return (
-        f"[Interface language: {name}. Respond in {name} unless the user clearly writes in a "
-        f"different language, in which case respond in that language. Do not mention this note.]"
+        f"The interface language is {name}. Respond in {name} unless the user clearly "
+        f"writes in another language, in which case respond in that language."
     )
 
 
-# ==============================================================================
-# ==                       Server-emitted user-facing text                    ==
-# ==============================================================================
-# key -> {language: text}. Keep every key populated for all of LANGUAGES.
-_MESSAGES: dict[str, dict[str, str]] = {
-    "error_interrupted": {
+# ===========================================================================
+# ==                    Server-emitted user-facing text                    ==
+# ===========================================================================
+class MessageKey(StrEnum):
+    """Keys for server-emitted, user-facing strings (see `translate`)."""
+
+    ERROR_INTERRUPTED = "error_interrupted"
+    ERROR_MODEL_CALL_LIMIT = "error_model_call_limit"
+    ERROR_UNEXPECTED = "error_unexpected"
+    RESULTS_EXPIRED = "results_expired"
+    RESULTS_TOO_LARGE = "results_too_large"
+    DEFAULT_EXPORT_FILENAME = "default_export_filename"
+
+
+# Keep every key populated for all of _LANGUAGES (enforced by tests).
+_MESSAGES = {
+    MessageKey.ERROR_INTERRUPTED: {
         "pt": "A conexão com o servidor foi interrompida. Por favor, tente novamente.",
         "en": "The connection to the server was interrupted. Please try again.",
         "es": "Se interrumpió la conexión con el servidor. Por favor, inténtalo de nuevo.",
     },
-    "error_model_call_limit": {
+    MessageKey.ERROR_MODEL_CALL_LIMIT: {
         "pt": (
             "Essa pergunta gerou um raciocínio muito longo e não consegui chegar a uma "
             "conclusão. Por favor, tente ser mais específico ou divida sua pergunta em "
@@ -86,31 +104,22 @@ _MESSAGES: dict[str, dict[str, str]] = {
             "pequeñas."
         ),
     },
-    "error_unexpected": {
-        "pt": (
-            "Ocorreu um erro inesperado. Por favor, tente novamente. Se o problema "
-            "persistir, avise-nos."
-        ),
-        "en": (
-            "An unexpected error occurred. Please try again. If the problem persists, let "
-            "us know."
-        ),
-        "es": (
-            "Ocurrió un error inesperado. Inténtalo de nuevo. Si el problema persiste, "
-            "avísanos."
-        ),
+    MessageKey.ERROR_UNEXPECTED: {
+        "pt": "Ocorreu um erro inesperado. Por favor, tente novamente. Se o problema persistir, avise-nos.",
+        "en": "An unexpected error occurred. Please try again. If the problem persists, let us know.",
+        "es": "Ocurrió un error inesperado. Inténtalo de nuevo. Si el problema persiste, avísanos.",
     },
-    "results_expired": {
+    MessageKey.RESULTS_EXPIRED: {
         "pt": "Estes resultados não estão mais disponíveis para download.",
         "en": "These results are no longer available for download.",
         "es": "Estos resultados ya no están disponibles para descargar.",
     },
-    "results_too_large": {
+    MessageKey.RESULTS_TOO_LARGE: {
         "pt": "Estes resultados são grandes demais para baixar em um único arquivo.",
         "en": "These results are too large to download in a single file.",
         "es": "Estos resultados son demasiado grandes para descargar en un solo archivo.",
     },
-    "default_export_filename": {
+    MessageKey.DEFAULT_EXPORT_FILENAME: {
         "pt": "resultados",
         "en": "results",
         "es": "resultados",
@@ -118,40 +127,14 @@ _MESSAGES: dict[str, dict[str, str]] = {
 }
 
 
-def t(key: str, language: str) -> str:
+def translate(key: MessageKey, language: LanguageCode) -> str:
     """Return the localized string for `key` in `language`.
 
     Args:
-        key (str): A key present in `_MESSAGES`.
-        language (str): A language code (unsupported values fall back to the default).
+        key (MessageKey): The message to localize.
+        language (LanguageCode): A supported language code.
 
     Returns:
         str: The localized string.
     """
-    return _MESSAGES[key][normalize_language(language)]
-
-
-# GraphQL modeltranslation columns are exposed as `{field}Pt`/`{field}En`/`{field}Es`.
-_LANG_FIELD_SUFFIX: dict[str, str] = {"pt": "Pt", "en": "En", "es": "Es"}
-
-
-def localized_field(node: dict, field: str, language: str) -> str | None:
-    """Pick a GraphQL node's localized `field` for `language`, pt as fallback.
-
-    modeltranslation exposes per-language columns as `{field}Pt`/`{field}En`/
-    `{field}Es` (e.g. `name` -> `namePt`/`nameEn`/`nameEs`, `description` ->
-    `descriptionPt`/...). The unqualified accessor (`name`) is deliberately not
-    used: it returns the server's active-language value, ambiguous for a
-    headless request.
-
-    Args:
-        node (dict): A GraphQL node exposing the modeltranslation columns.
-        field (str): The base field name, e.g. "name" or "description".
-        language (str): A language code; unsupported values fall back to default.
-
-    Returns:
-        str | None: The requested language's value, the pt value when it is empty
-            (coverage is partial), or None when neither is set.
-    """
-    suffix = _LANG_FIELD_SUFFIX[normalize_language(language)]
-    return node.get(f"{field}{suffix}") or node.get(f"{field}Pt")
+    return _MESSAGES[key][language]

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,5 @@
 import asyncio
 from contextlib import asynccontextmanager
-from datetime import date
 
 from fastapi import FastAPI
 from fastapi.responses import RedirectResponse
@@ -15,6 +14,8 @@ from loguru import logger
 from psycopg.rows import dict_row
 from psycopg_pool import AsyncConnectionPool
 
+from app.agent.context import AgentContext
+from app.agent.middleware import system_prompt_middleware
 from app.agent.prompts import SYSTEM_PROMPT
 from app.agent.schemas import StructuredResponse
 from app.agent.tools import BDToolkit
@@ -84,11 +85,14 @@ async def lifespan(app: FastAPI):  # pragma: no cover
             agent = create_agent(
                 model=model,
                 tools=BDToolkit.get_tools(),
-                system_prompt=SYSTEM_PROMPT.format(
-                    current_date=date.today().isoformat()
-                ),
-                middleware=[summ_middleware, limit_middleware],
+                system_prompt=SYSTEM_PROMPT,
+                middleware=[
+                    system_prompt_middleware,
+                    summ_middleware,
+                    limit_middleware,
+                ],
                 response_format=StructuredResponse,
+                context_schema=AgentContext,
                 checkpointer=checkpointer,
             )
 

--- a/tests/app/agent/test_middleware.py
+++ b/tests/app/agent/test_middleware.py
@@ -1,0 +1,72 @@
+from datetime import date
+
+import pytest
+from langchain.agents import create_agent
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage, BaseMessage
+
+from app.agent.context import AgentContext
+from app.agent.middleware import system_prompt_middleware
+from app.i18n import LanguageCode, language_directive
+
+# A template mirroring the real prompt's placeholders (see app.agent.prompts.SYSTEM_PROMPT).
+PROMPT_TEMPLATE = "Today is {current_date}.\n{language_directive}"
+
+
+class _SpyModel(GenericFakeChatModel):
+    """Fake model that records the system message it was asked to answer with."""
+
+    system_seen: str = ""
+
+    def _generate(self, messages: list[BaseMessage], *args, **kwargs):
+        type(self).system_seen = messages[0].content
+        return super()._generate(messages, *args, **kwargs)
+
+
+def _system_prompt_for(language: LanguageCode) -> str:
+    model = _SpyModel(messages=iter([AIMessage(content="ok")]))
+    agent = create_agent(
+        model=model,
+        tools=[],
+        system_prompt=PROMPT_TEMPLATE,
+        middleware=[system_prompt_middleware],
+        context_schema=AgentContext,
+    )
+    agent.invoke(
+        {"messages": [{"role": "user", "content": "oi"}]},
+        context=AgentContext(thread_id="t", user_id="u", language=language),
+    )
+    return _SpyModel.system_seen
+
+
+class TestSystemPromptMiddleware:
+    @pytest.mark.parametrize("language", ["pt", "en", "es"])
+    def test_fills_language_directive_placeholder(self, language: str):
+        system = _system_prompt_for(language)
+
+        assert language_directive(language) in system
+        assert "{language_directive}" not in system
+
+    def test_fills_current_date_placeholder(self):
+        system = _system_prompt_for("pt")
+
+        assert date.today().isoformat() in system
+        assert "{current_date}" not in system
+
+    def test_user_message_is_left_untouched(self):
+        """The directive rides on the system prompt, never the user's message."""
+        model = _SpyModel(messages=iter([AIMessage(content="ok")]))
+        agent = create_agent(
+            model=model,
+            tools=[],
+            system_prompt=PROMPT_TEMPLATE,
+            middleware=[system_prompt_middleware],
+            context_schema=AgentContext,
+        )
+
+        result = agent.invoke(
+            {"messages": [{"role": "user", "content": "oi"}]},
+            context=AgentContext(thread_id="t", user_id="u", language="en"),
+        )
+
+        assert result["messages"][0].content == "oi"

--- a/tests/app/agent/tools/test_api.py
+++ b/tests/app/agent/tools/test_api.py
@@ -3,14 +3,45 @@ import json
 import httpx
 import pytest
 import respx
+from langchain.tools import ToolRuntime
 
+from app.agent.context import AgentContext
 from app.agent.tools.api import (
+    BASE_USAGE_GUIDE_URL,
     SKIP_DIRECTORY_DATASETS,
+    _fetch_usage_guide,
     get_dataset_details,
     get_table_details,
     search_datasets,
 )
 from app.settings import settings
+
+
+def _build_tool_runtime(context: AgentContext) -> ToolRuntime[AgentContext]:
+    """Build a ToolRuntime the way the agent's ToolNode injects it into a tool.
+
+    Only `context` varies between tests; the other slots are inert stand-ins for
+    graph plumbing the tools under test never read.
+    """
+    return ToolRuntime(
+        state={},
+        context=context,
+        config={},
+        stream_writer=None,
+        tool_call_id="test-tool-call",
+        store=None,
+    )
+
+
+def _runtime(language: str = "pt") -> ToolRuntime[AgentContext]:
+    """A ToolRuntime for the given language (thread/user ids are irrelevant here)."""
+    return _build_tool_runtime(
+        AgentContext(
+            thread_id="test-thread",
+            user_id="test-user",
+            language=language,
+        )
+    )
 
 
 class TestSearchDatasets:
@@ -41,7 +72,7 @@ class TestSearchDatasets:
             return_value=httpx.Response(200, json=mock_response)
         )
 
-        result = await search_datasets.ainvoke({"query": "test"})
+        result = await search_datasets.ainvoke({"query": "test", "runtime": _runtime()})
         output = json.loads(result)
 
         assert len(output) == 1
@@ -62,10 +93,23 @@ class TestSearchDatasets:
             return_value=httpx.Response(200, json={"results": []})
         )
 
-        result = await search_datasets.ainvoke({"query": "nonexistent"})
+        result = await search_datasets.ainvoke(
+            {"query": "nonexistent", "runtime": _runtime()}
+        )
         output = json.loads(result)
 
         assert output == []
+
+    @respx.mock
+    async def test_forwards_context_language_as_locale(self):
+        """The thread's language is sent as the `locale` so the API returns localized text."""
+        route = respx.get(self.SEARCH_ENDPOINT).mock(
+            return_value=httpx.Response(200, json={"results": []})
+        )
+
+        await search_datasets.ainvoke({"query": "x", "runtime": _runtime("es")})
+
+        assert route.calls.last.request.url.params["locale"] == "es"
 
 
 class TestGetDatasetDetails:
@@ -88,7 +132,12 @@ class TestGetDatasetDetails:
                                 "themes": {"edges": [{"node": {"namePt": "theme1"}}]},
                                 "organizations": {
                                     "edges": [
-                                        {"node": {"namePt": "org1", "slug": "org1_slug"}}
+                                        {
+                                            "node": {
+                                                "namePt": "org1",
+                                                "slug": "org1_slug",
+                                            }
+                                        }
                                     ]
                                 },
                                 "tables": {
@@ -137,7 +186,9 @@ class TestGetDatasetDetails:
             return_value=httpx.Response(404)
         )
 
-        result = await get_dataset_details.ainvoke({"dataset_id": "dataset-1"})
+        result = await get_dataset_details.ainvoke(
+            {"dataset_id": "dataset-1", "runtime": _runtime()}
+        )
         dataset = json.loads(result)
 
         assert dataset["id"] == "dataset-1"
@@ -168,7 +219,9 @@ class TestGetDatasetDetails:
             return_value=httpx.Response(200, text="# This is a usage guide.")
         )
 
-        result = await get_dataset_details.ainvoke({"dataset_id": "dataset-1"})
+        result = await get_dataset_details.ainvoke(
+            {"dataset_id": "dataset-1", "runtime": _runtime()}
+        )
         dataset = json.loads(result)
 
         assert dataset["usage_guide"] == "# This is a usage guide."
@@ -229,7 +282,9 @@ class TestGetDatasetDetails:
             return_value=httpx.Response(200)
         )
 
-        result = await get_dataset_details.ainvoke({"dataset_id": "dataset-1"})
+        result = await get_dataset_details.ainvoke(
+            {"dataset_id": "dataset-1", "runtime": _runtime()}
+        )
         dataset = json.loads(result)
 
         assert dataset["tags"] == []
@@ -253,7 +308,12 @@ class TestGetDatasetDetails:
                                 "themes": {"edges": [{"node": {"namePt": "theme1"}}]},
                                 "organizations": {
                                     "edges": [
-                                        {"node": {"namePt": "org1", "slug": "org1_slug"}}
+                                        {
+                                            "node": {
+                                                "namePt": "org1",
+                                                "slug": "org1_slug",
+                                            }
+                                        }
                                     ]
                                 },
                                 "tables": {
@@ -284,7 +344,9 @@ class TestGetDatasetDetails:
             return_value=httpx.Response(200, json=mock_response)
         )
 
-        result = await get_dataset_details.ainvoke({"dataset_id": "dataset-1"})
+        result = await get_dataset_details.ainvoke(
+            {"dataset_id": "dataset-1", "runtime": _runtime()}
+        )
         dataset = json.loads(result)
 
         assert dataset["tables"][0]["gcp_id"] is None
@@ -299,7 +361,9 @@ class TestGetDatasetDetails:
             )
         )
 
-        result = await get_dataset_details.ainvoke({"dataset_id": "nonexistent"})
+        result = await get_dataset_details.ainvoke(
+            {"dataset_id": "nonexistent", "runtime": _runtime()}
+        )
         output = json.loads(result)
 
         assert output["status"] == "error"
@@ -307,6 +371,68 @@ class TestGetDatasetDetails:
             output["message"]
             == "Dataset 'nonexistent' not found. Verify the dataset ID from search_datasets results."
         )
+
+    @respx.mock
+    async def test_localizes_metadata_to_context_language(self):
+        """Each field is picked in the thread's language, falling back to pt per field."""
+        mock_response = {
+            "data": {
+                "allDataset": {
+                    "edges": [
+                        {
+                            "node": {
+                                "id": "DatasetNode:dataset-1",
+                                "namePt": "Conjunto",
+                                "nameEn": "Dataset",
+                                # description has no English value -> must fall back to pt
+                                "descriptionPt": "Descrição",
+                                "descriptionEn": "",
+                                "tags": {
+                                    "edges": [
+                                        {
+                                            "node": {
+                                                "namePt": "saúde",
+                                                "nameEn": "health",
+                                            }
+                                        }
+                                    ]
+                                },
+                                "themes": {"edges": []},
+                                "organizations": {"edges": []},
+                                "tables": {
+                                    "edges": [
+                                        {
+                                            "node": {
+                                                "id": "TableNode:table-1",
+                                                "namePt": "Tabela",
+                                                "nameEn": "Table",
+                                                "descriptionPt": "Desc",
+                                                "descriptionEn": "Desc EN",
+                                                "cloudTables": {"edges": []},
+                                            }
+                                        }
+                                    ]
+                                },
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+        respx.post(self.GRAPHQL_URL).mock(
+            return_value=httpx.Response(200, json=mock_response)
+        )
+
+        result = await get_dataset_details.ainvoke(
+            {"dataset_id": "dataset-1", "runtime": _runtime("en")}
+        )
+        dataset = json.loads(result)
+
+        assert dataset["name"] == "Dataset"  # English picked
+        assert dataset["description"] == "Descrição"  # English empty -> pt fallback
+        assert dataset["tags"] == ["health"]  # English picked
+        assert dataset["tables"][0]["name"] == "Table"  # English picked
 
 
 class TestGetTableDetails:
@@ -439,7 +565,9 @@ class TestGetTableDetails:
             return_value=httpx.Response(200, json=mock_response)
         )
 
-        result = await get_table_details.ainvoke({"table_id": "table-1"})
+        result = await get_table_details.ainvoke(
+            {"table_id": "table-1", "runtime": _runtime()}
+        )
         table = json.loads(result)
 
         assert table["id"] == "table-1"
@@ -490,7 +618,9 @@ class TestGetTableDetails:
             return_value=httpx.Response(200, json=mock_response)
         )
 
-        result = await get_table_details.ainvoke({"table_id": "table-1"})
+        result = await get_table_details.ainvoke(
+            {"table_id": "table-1", "runtime": _runtime()}
+        )
         table = json.loads(result)
 
         assert table["period_start"] is None
@@ -507,7 +637,9 @@ class TestGetTableDetails:
             return_value=httpx.Response(200, json=mock_response)
         )
 
-        result = await get_table_details.ainvoke({"table_id": "table-1"})
+        result = await get_table_details.ainvoke(
+            {"table_id": "table-1", "runtime": _runtime()}
+        )
         table = json.loads(result)
 
         assert table["gcp_id"] is None
@@ -519,7 +651,9 @@ class TestGetTableDetails:
             return_value=httpx.Response(200, json={"data": {"allTable": {"edges": []}}})
         )
 
-        result = await get_table_details.ainvoke({"table_id": "nonexistent"})
+        result = await get_table_details.ainvoke(
+            {"table_id": "nonexistent", "runtime": _runtime()}
+        )
         output = json.loads(result)
 
         assert output["status"] == "error"
@@ -527,3 +661,109 @@ class TestGetTableDetails:
             output["message"]
             == "Table 'nonexistent' not found. Verify the table ID from get_dataset_details results."
         )
+
+    @respx.mock
+    async def test_localizes_metadata_to_context_language(self):
+        """Table/column metadata is picked in the thread's language, pt as per-field fallback."""
+        mock_response = {
+            "data": {
+                "allTable": {
+                    "edges": [
+                        {
+                            "node": {
+                                "id": "TableNode:table-1",
+                                "namePt": "Tabela",
+                                "nameEn": "Table",
+                                # no English description -> must fall back to pt
+                                "descriptionPt": "Descrição",
+                                "descriptionEn": "",
+                                "temporalCoverage": None,
+                                "cloudTables": {"edges": []},
+                                "columns": {
+                                    "edges": [
+                                        {
+                                            "node": {
+                                                "id": "col-1",
+                                                "name": "status",
+                                                "descriptionPt": "Situação",
+                                                "descriptionEn": "Status",
+                                                "measurementUnit": None,
+                                                "coveredByDictionary": False,
+                                                "isPartition": False,
+                                                "bigqueryType": {"name": "STRING"},
+                                                "directoryPrimaryKey": None,
+                                            }
+                                        }
+                                    ]
+                                },
+                                "dataset": {"id": "DatasetNode:dataset-1"},
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+        respx.post(self.GRAPHQL_URL).mock(
+            return_value=httpx.Response(200, json=mock_response)
+        )
+
+        result = await get_table_details.ainvoke(
+            {"table_id": "table-1", "runtime": _runtime("en")}
+        )
+        table = json.loads(result)
+
+        assert table["name"] == "Table"  # English picked
+        assert table["description"] == "Descrição"  # English empty -> pt fallback
+        assert table["columns"][0]["description"] == "Status"  # English picked
+
+
+class TestFetchUsageGuide:
+    """The localized usage-guide fetch: requested language, then the default, deduped."""
+
+    GCP_DATASET_ID = "test_dataset"
+    FILENAME = "test-dataset"  # underscores become dashes in the guide filename
+
+    def _url(self, locale: str) -> str:
+        return f"{BASE_USAGE_GUIDE_URL}/{locale}/{self.FILENAME}.md"
+
+    @respx.mock
+    async def test_returns_requested_language_guide(self):
+        respx.get(self._url("en")).mock(
+            return_value=httpx.Response(200, text="# EN guide")
+        )
+
+        assert await _fetch_usage_guide(self.GCP_DATASET_ID, "en") == "# EN guide"
+
+    @respx.mock
+    async def test_falls_back_to_default_when_localized_missing(self):
+        respx.get(self._url("en")).mock(return_value=httpx.Response(404))
+        pt = respx.get(self._url("pt")).mock(
+            return_value=httpx.Response(200, text="# PT guide")
+        )
+
+        assert await _fetch_usage_guide(self.GCP_DATASET_ID, "en") == "# PT guide"
+        assert pt.called
+
+    @respx.mock
+    async def test_default_language_fetches_once(self):
+        pt = respx.get(self._url("pt")).mock(
+            return_value=httpx.Response(200, text="# PT guide")
+        )
+        en = respx.get(self._url("en")).mock(
+            return_value=httpx.Response(200, text="# EN guide")
+        )
+
+        assert await _fetch_usage_guide(self.GCP_DATASET_ID, "pt") == "# PT guide"
+        assert pt.call_count == 1
+        assert (
+            not en.called
+        )  # dedupe: no second fetch when language is already the default
+
+    @respx.mock
+    async def test_returns_none_when_no_guide_exists(self):
+        respx.get(url__startswith=BASE_USAGE_GUIDE_URL).mock(
+            return_value=httpx.Response(404)
+        )
+
+        assert await _fetch_usage_guide(self.GCP_DATASET_ID, "en") is None

--- a/tests/app/agent/tools/test_bigquery.py
+++ b/tests/app/agent/tools/test_bigquery.py
@@ -5,9 +5,11 @@ from unittest.mock import MagicMock
 import pytest
 from google.api_core.exceptions import BadRequest, NotFound
 from google.cloud import bigquery as bq
+from langchain.tools import ToolRuntime
 from langchain_core.messages import ToolMessage
 from pytest_mock import MockerFixture
 
+from app.agent.context import AgentContext
 from app.agent.tools.bigquery import (
     MAX_BYTES_BILLED,
     decode_table_values,
@@ -16,27 +18,52 @@ from app.agent.tools.bigquery import (
 
 
 @pytest.fixture
-def mock_config() -> dict:
-    return {"configurable": {"thread_id": "test-thread", "user_id": "test-user"}}
+def mock_context() -> AgentContext:
+    """The run context the agent injects into a tool
+    (its `thread_id`/`user_id` become the BigQuery job labels)."""
+    return AgentContext(thread_id="test-thread", user_id="test-user", language="pt")
 
 
-def _invoke_tool(tool, args: dict, config: dict | None = None) -> ToolMessage:
+def _build_tool_runtime(context: AgentContext) -> ToolRuntime[AgentContext]:
+    """Build a ToolRuntime the way the agent's ToolNode injects it into a tool.
+
+    Only `context` varies between tests; the other slots are inert stand-ins for
+    graph plumbing the tools under test never read.
+    """
+    return ToolRuntime(
+        state={},
+        context=context,
+        config={},
+        stream_writer=None,
+        tool_call_id="test-tool-call",
+        store=None,
+    )
+
+
+def _invoke_tool(tool, args: dict, context: AgentContext) -> ToolMessage:
     """Invoke a tool the way the agent's ToolNode does, returning the ToolMessage.
 
     The tool-call form (rather than a plain args dict) exercises the real
     content+artifact packaging, so the ToolMessage exposes both `.content` and,
-    for content_and_artifact tools, `.artifact`.
+    for content_and_artifact tools, `.artifact`. `context` is injected as the tool
+    runtime — the same AgentContext the agent provides at run time.
     """
+    runtime = _build_tool_runtime(context)
+
     return tool.invoke(
-        {"type": "tool_call", "id": "1", "name": tool.name, "args": args},
-        config=config,
+        {
+            "type": "tool_call",
+            "id": "1",
+            "name": tool.name,
+            "args": {**args, "runtime": runtime},
+        }
     )
 
 
 class TestExecuteBigQuerySQL:
     """Tests for execute_bigquery_sql tool."""
 
-    def test_successful_query(self, mocker: MockerFixture, mock_config: dict):
+    def test_successful_query(self, mocker: MockerFixture, mock_context: AgentContext):
         """Test successful SELECT query returns rows plus a query_ref handle."""
         mock_dry_run_query_job = MagicMock()
         mock_dry_run_query_job.statement_type = "SELECT"
@@ -62,7 +89,7 @@ class TestExecuteBigQuerySQL:
         message = _invoke_tool(
             execute_bigquery_sql,
             {"sql_query": "SELECT * FROM project.dataset.table", "slug": "resultado"},
-            config=mock_config,
+            context=mock_context,
         )
 
         output = json.loads(message.content)
@@ -72,7 +99,7 @@ class TestExecuteBigQuerySQL:
         assert re.fullmatch(r"qr_[0-9a-f]{32}", message.artifact["query_ref"])
 
     def test_successful_query_exposes_destination_table_on_artifact(
-        self, mocker: MockerFixture, mock_config: dict
+        self, mocker: MockerFixture, mock_context: AgentContext
     ):
         """The result table reference is carried on the artifact, not the content."""
         mock_dry_run_query_job = MagicMock()
@@ -99,7 +126,7 @@ class TestExecuteBigQuerySQL:
         message = _invoke_tool(
             execute_bigquery_sql,
             {"sql_query": "SELECT * FROM project.dataset.table", "slug": "resultado"},
-            config=mock_config,
+            context=mock_context,
         )
 
         assert message.artifact["type"] == "query_result"
@@ -112,7 +139,7 @@ class TestExecuteBigQuerySQL:
         }
 
     def test_successful_query_empty_result(
-        self, mocker: MockerFixture, mock_config: dict
+        self, mocker: MockerFixture, mock_context: AgentContext
     ):
         """A query with no rows returns a message and no downloadable handle."""
         mock_dry_run_query_job = MagicMock()
@@ -134,7 +161,7 @@ class TestExecuteBigQuerySQL:
         message = _invoke_tool(
             execute_bigquery_sql,
             {"sql_query": "SELECT * FROM project.dataset.table", "slug": "resultado"},
-            config=mock_config,
+            context=mock_context,
         )
 
         assert (
@@ -143,7 +170,9 @@ class TestExecuteBigQuerySQL:
         )
         assert message.artifact is None
 
-    def test_forbidden_statement_type(self, mocker: MockerFixture, mock_config: dict):
+    def test_forbidden_statement_type(
+        self, mocker: MockerFixture, mock_context: AgentContext
+    ):
         """Test error when statement is not SELECT."""
         mock_dry_run_query_job = MagicMock()
         mock_dry_run_query_job.statement_type = "DELETE"
@@ -158,7 +187,7 @@ class TestExecuteBigQuerySQL:
         message = _invoke_tool(
             execute_bigquery_sql,
             {"sql_query": "DELETE FROM project.dataset.table", "slug": "resultado"},
-            config=mock_config,
+            context=mock_context,
         )
 
         output = json.loads(message.content)
@@ -167,7 +196,7 @@ class TestExecuteBigQuerySQL:
         assert output["message"] == "Only SELECT statements are allowed, got DELETE."
 
     def test_bytes_billed_limit_exceeded(
-        self, mocker: MockerFixture, mock_config: dict
+        self, mocker: MockerFixture, mock_context: AgentContext
     ):
         """Test error when query exceeds bytes billed limit."""
         mock_dry_run_query_job = MagicMock()
@@ -190,7 +219,7 @@ class TestExecuteBigQuerySQL:
         message = _invoke_tool(
             execute_bigquery_sql,
             {"sql_query": "SELECT * FROM project.dataset.table", "slug": "resultado"},
-            config=mock_config,
+            context=mock_context,
         )
 
         output = json.loads(message.content)
@@ -201,7 +230,9 @@ class TestExecuteBigQuerySQL:
             "Filter by partitioned columns."
         )
 
-    def test_google_api_error_reraise(self, mocker: MockerFixture, mock_config: dict):
+    def test_google_api_error_reraise(
+        self, mocker: MockerFixture, mock_context: AgentContext
+    ):
         """Test that non-bytesBilledLimitExceeded GoogleAPICallError is re-raised."""
         mock_dry_run_query_job = MagicMock()
         mock_dry_run_query_job.statement_type = "SELECT"
@@ -221,7 +252,7 @@ class TestExecuteBigQuerySQL:
         message = _invoke_tool(
             execute_bigquery_sql,
             {"sql_query": "SELECT * FROM project.dataset.table", "slug": "resultado"},
-            config=mock_config,
+            context=mock_context,
         )
 
         output = json.loads(message.content)
@@ -233,7 +264,9 @@ class TestExecuteBigQuerySQL:
 class TestDecodeTableValues:
     """Tests for decode_table_values tool."""
 
-    def test_decode_all_columns(self, mocker: MockerFixture, mock_config: dict):
+    def test_decode_all_columns(
+        self, mocker: MockerFixture, mock_context: AgentContext
+    ):
         """Test decoding all columns from a table."""
         mock_query_job = MagicMock()
         mock_query_job.result.return_value = [
@@ -251,7 +284,7 @@ class TestDecodeTableValues:
         message = _invoke_tool(
             decode_table_values,
             {"table_gcp_id": "project.dataset.table"},
-            config=mock_config,
+            context=mock_context,
         )
 
         output = json.loads(message.content)
@@ -268,7 +301,7 @@ class TestDecodeTableValues:
         assert "nome_coluna = " not in param_names
 
     def test_decode_all_columns_with_backticks(
-        self, mocker: MockerFixture, mock_config: dict
+        self, mocker: MockerFixture, mock_context: AgentContext
     ):
         """Test decoding all columns from a table with backticks in its name."""
         mock_query_job = MagicMock()
@@ -287,7 +320,7 @@ class TestDecodeTableValues:
         message = _invoke_tool(
             decode_table_values,
             {"table_gcp_id": "`project.dataset.table`"},
-            config=mock_config,
+            context=mock_context,
         )
 
         output = json.loads(message.content)
@@ -303,7 +336,9 @@ class TestDecodeTableValues:
         assert "table_name" in param_names
         assert "nome_coluna = " not in param_names
 
-    def test_decode_specific_column(self, mocker: MockerFixture, mock_config: dict):
+    def test_decode_specific_column(
+        self, mocker: MockerFixture, mock_context: AgentContext
+    ):
         """Test decoding a specific column."""
         mock_query_job = MagicMock()
         mock_query_job.result.return_value = [
@@ -321,7 +356,7 @@ class TestDecodeTableValues:
         message = _invoke_tool(
             decode_table_values,
             {"table_gcp_id": "project.dataset.table", "column_name": "col1"},
-            config=mock_config,
+            context=mock_context,
         )
 
         output = json.loads(message.content)
@@ -337,7 +372,9 @@ class TestDecodeTableValues:
         assert "table_name" in param_names
         assert "column_name" in param_names
 
-    def test_dictionary_not_found(self, mocker: MockerFixture, mock_config: dict):
+    def test_dictionary_not_found(
+        self, mocker: MockerFixture, mock_context: AgentContext
+    ):
         """Test error when dictionary table doesn't exist."""
         error = NotFound(
             message="Table not found",
@@ -354,7 +391,7 @@ class TestDecodeTableValues:
         message = _invoke_tool(
             decode_table_values,
             {"table_gcp_id": "project.dataset.table"},
-            config=mock_config,
+            context=mock_context,
         )
 
         output = json.loads(message.content)
@@ -362,10 +399,10 @@ class TestDecodeTableValues:
         assert output["status"] == "error"
         assert output["message"] == "Dictionary table not found for this dataset."
 
-    def test_invalid_table_reference(self, mock_config: dict):
+    def test_invalid_table_reference(self, mock_context: AgentContext):
         """Test error when table reference format is invalid."""
         message = _invoke_tool(
-            decode_table_values, {"table_gcp_id": "table"}, config=mock_config
+            decode_table_values, {"table_gcp_id": "table"}, context=mock_context
         )
 
         output = json.loads(message.content)
@@ -376,7 +413,9 @@ class TestDecodeTableValues:
             == "Invalid table reference: 'table'. Expected format: project.dataset.table"
         )
 
-    def test_google_api_error_reraise(self, mocker: MockerFixture, mock_config: dict):
+    def test_google_api_error_reraise(
+        self, mocker: MockerFixture, mock_context: AgentContext
+    ):
         """Test that non-notFound GoogleAPICallError is re-raised."""
         error = BadRequest(
             message="Syntax error",
@@ -393,7 +432,7 @@ class TestDecodeTableValues:
         message = _invoke_tool(
             decode_table_values,
             {"table_gcp_id": "project.dataset.table"},
-            config=mock_config,
+            context=mock_context,
         )
 
         output = json.loads(message.content)

--- a/tests/app/api/routers/test_chatbot.py
+++ b/tests/app/api/routers/test_chatbot.py
@@ -43,6 +43,7 @@ class MockLangSmithFeedbackSender:
 class MockAgent:
     def __init__(self, checkpointer=None):
         self.checkpointer = checkpointer
+        self.captured_config = None
 
     def invoke(self, input, config):
         return {"messages": [AIMessage("Mock response")]}
@@ -56,6 +57,7 @@ class MockAgent:
         yield "values", chunk
 
     async def astream(self, input, config, stream_mode, context=None):
+        self.captured_config = config
         chunk = {"model": {"messages": [AIMessage("Mock response")]}}
         yield "updates", chunk
         yield "values", chunk
@@ -520,6 +522,37 @@ class TestSendMessageEndpoint:
         assert any(event.type == "final_answer" for event in events)
         assert events[-1].type == "complete"
         assert events[-1].data.run_id is not None
+
+    async def test_send_message_sets_trace_metadata(
+        self,
+        client: TestClient,
+        access_token: str,
+        database: AsyncDatabase,
+        user_id: str,
+    ):
+        """The run config carries thread_id/user_id/language as `metadata` — what
+        LangSmith surfaces as trace attributes (see app.api.schemas.ConfigDict)."""
+        thread = await database.create_thread(
+            ThreadCreate(title="ES thread", user_id=user_id, language="es")
+        )
+
+        response = client.post(
+            url=f"/api/v1/chatbot/threads/{thread.id}/messages",
+            json={"content": "hola"},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        # Drain the stream so the background run_agent task dispatches to the agent.
+        for _ in response.iter_lines():
+            pass
+
+        assert app.state.agent.captured_config["metadata"] == {
+            "thread_id": str(thread.id),
+            "user_id": user_id,
+            "language": "es",
+        }
 
     def test_send_message_missing_content(
         self, client: TestClient, access_token: str, thread: Thread

--- a/tests/app/api/routers/test_chatbot.py
+++ b/tests/app/api/routers/test_chatbot.py
@@ -26,8 +26,10 @@ from app.db.models import (
     MessageStatus,
     QueryHandle,
     Thread,
+    ThreadCreate,
 )
 from app.exports import ExportedFile, ResultTableExpired, ResultTooLarge
+from app.i18n import MessageKey, translate
 from app.main import app
 from app.settings import settings
 from tests.conftest import MessagesFactory, ThreadFactory
@@ -48,12 +50,12 @@ class MockAgent:
     async def ainvoke(self, input, config):
         return {"messages": [AIMessage("Mock response")]}
 
-    def stream(self, input, config, stream_mode):
+    def stream(self, input, config, stream_mode, context=None):
         chunk = {"model": {"messages": [AIMessage("Mock response")]}}
         yield "updates", chunk
         yield "values", chunk
 
-    async def astream(self, input, config, stream_mode):
+    async def astream(self, input, config, stream_mode, context=None):
         chunk = {"model": {"messages": [AIMessage("Mock response")]}}
         yield "updates", chunk
         yield "values", chunk
@@ -240,6 +242,20 @@ class TestCreateThreadEndpoint:
         thread = Thread.model_validate(response.json())
 
         assert thread.title == "Mock Title"
+        assert thread.language == "pt"  # default when the client omits it
+
+    def test_create_thread_normalizes_and_persists_language(
+        self, client: TestClient, access_token: str
+    ):
+        """A locale from the request body is normalized and stored on the thread."""
+        response = client.post(
+            url="/api/v1/chatbot/threads",
+            json={"title": "Mock Title", "language": "EN"},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert Thread.model_validate(response.json()).language == "en"
 
     def test_create_thread_missing_title(self, client: TestClient, access_token: str):
         """Test thread creation without title field."""
@@ -907,6 +923,52 @@ class TestExportMessageResultsEndpoint:
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    async def test_failure_detail_uses_thread_language(
+        self,
+        client: TestClient,
+        access_token: str,
+        database: AsyncDatabase,
+        user_id: str,
+        mocker: MockerFixture,
+    ):
+        """Download-failure details are localized to the owning thread's language."""
+        thread = await database.create_thread(
+            ThreadCreate(title="ES thread", user_id=user_id, language="es")
+        )
+        message = await database.create_message(
+            MessageCreate(
+                thread_id=thread.id,
+                model_uri="mock-model",
+                role=MessageRole.ASSISTANT,
+                content="Respuesta",
+                status=MessageStatus.SUCCESS,
+            )
+        )
+        await database.create_query_handles(
+            [
+                QueryHandle(
+                    query_ref="qr_test",
+                    message_id=message.id,
+                    slug="resultado",
+                    destination_table=self.DESTINATION,
+                )
+            ]
+        )
+        mocker.patch(
+            "app.api.routers.chatbot.materialize_export",
+            side_effect=ResultTooLarge("too large"),
+        )
+
+        response = client.post(
+            url=f"/api/v1/chatbot/messages/{message.id}/exports?query_ref=qr_test",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["detail"] == translate(
+            MessageKey.RESULTS_TOO_LARGE, "es"
+        )
 
     def test_missing_query_ref_param_is_unprocessable(
         self, client: TestClient, access_token: str, downloadable_message: Message

--- a/tests/app/api/streaming/test_agent_runner.py
+++ b/tests/app/api/streaming/test_agent_runner.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from langchain_core.messages import AIMessage, ToolMessage
 
+from app.agent.context import AgentContext
 from app.agent.schemas import (
     DataSource,
     StructuredResponse,
@@ -23,7 +24,7 @@ from app.api.streaming.agent_runner import (
 from app.api.streaming.schemas import StreamEvent
 from app.db.models import Message, MessageCreate, MessageRole, MessageStatus
 from app.exports import OFFERED_EXPORT_FORMATS
-from app.i18n import t
+from app.i18n import MessageKey, translate
 
 MODEL_URI = "mock-model"
 
@@ -212,7 +213,7 @@ class TestProcessChunk:
             }
         }
 
-        event = _process_chunk(chunk)
+        event = _process_chunk(chunk, "pt")
 
         assert event is not None
         assert event.type == "tool_call"
@@ -248,7 +249,7 @@ class TestProcessChunk:
             }
         }
 
-        event = _process_chunk(chunk)
+        event = _process_chunk(chunk, "pt")
 
         assert event is not None
         assert event.type == "tool_call"
@@ -260,7 +261,7 @@ class TestProcessChunk:
         """Test agent chunk without tool calls returns final_answer event."""
         chunk = {"model": {"messages": [AIMessage(content="Here is your answer.")]}}
 
-        event = _process_chunk(chunk)
+        event = _process_chunk(chunk, "pt")
 
         assert event is not None
         assert event.type == "final_answer"
@@ -274,7 +275,7 @@ class TestProcessChunk:
         """Test agent chunk with empty messages list returns empty final_answer."""
         chunk = {"model": {"messages": []}}
 
-        event = _process_chunk(chunk)
+        event = _process_chunk(chunk, "pt")
 
         assert event is not None
         assert event.type == "final_answer"
@@ -316,7 +317,7 @@ class TestProcessChunk:
             }
         }
 
-        event = _process_chunk(chunk)
+        event = _process_chunk(chunk, "pt")
 
         assert event is not None
         assert event.type == "final_answer"
@@ -351,7 +352,7 @@ class TestProcessChunk:
             }
         }
 
-        event = _process_chunk(chunk)
+        event = _process_chunk(chunk, "pt")
 
         assert event is not None
         assert event.type == "final_answer"
@@ -373,7 +374,7 @@ class TestProcessChunk:
             }
         }
 
-        event = _process_chunk(chunk)
+        event = _process_chunk(chunk, "pt")
 
         assert event is not None
         assert event.type == "tool_output"
@@ -412,7 +413,7 @@ class TestProcessChunk:
             }
         }
 
-        event = _process_chunk(chunk)
+        event = _process_chunk(chunk, "pt")
         output = event.data.tool_outputs[0]
 
         # In memory the handle is present (run_agent reads destination_table off it) ...
@@ -443,7 +444,7 @@ class TestProcessChunk:
             }
         }
 
-        event = _process_chunk(chunk)
+        event = _process_chunk(chunk, "pt")
         output = event.data.tool_outputs[0]
 
         # A client-facing artifact passes through redaction untouched, in memory ...
@@ -479,7 +480,7 @@ class TestProcessChunk:
             ]
         }
 
-        event = _process_chunk(chunk)
+        event = _process_chunk(chunk, "pt")
 
         assert event is not None
         assert event.type == "tool_output"
@@ -502,7 +503,7 @@ class TestProcessChunk:
             }
         }
 
-        event = _process_chunk(chunk)
+        event = _process_chunk(chunk, "pt")
 
         assert event is not None
         assert event.type == "tool_output"
@@ -512,7 +513,7 @@ class TestProcessChunk:
         """Test tools chunk with unexpected format returns empty tool_outputs."""
         chunk = {"tools": "unexpected string"}
 
-        event = _process_chunk(chunk)
+        event = _process_chunk(chunk, "pt")
 
         assert event is not None
         assert event.type == "tool_output"
@@ -527,32 +528,32 @@ class TestProcessChunk:
             }
         }
 
-        event = _process_chunk(chunk)
+        event = _process_chunk(chunk, "pt")
 
         assert event is not None
         assert event.type == "model_call_limit"
-        assert event.data.content == t("error_model_call_limit", "pt")
+        assert event.data.content == translate(MessageKey.ERROR_MODEL_CALL_LIMIT, "pt")
 
     def test_model_call_limit_passthrough_chunk_returns_none(self):
         """Test before_model passthrough chunk (None payload) returns None."""
         chunk = {"ModelCallLimitMiddleware.before_model": None}
-        assert _process_chunk(chunk) is None
+        assert _process_chunk(chunk, "pt") is None
 
     def test_model_call_limit_passthrough_chunk_no_jump_returns_none(self):
         """Test before_model chunk without jump_to returns None."""
         chunk = {"ModelCallLimitMiddleware.before_model": {"messages": []}}
-        assert _process_chunk(chunk) is None
+        assert _process_chunk(chunk, "pt") is None
 
     def test_unrecognized_chunk_returns_none(self):
         """Test unrecognized chunk returns None."""
         chunk = {"unknown_node": {"data": "something"}}
-        event = _process_chunk(chunk)
+        event = _process_chunk(chunk, "pt")
         assert event is None
 
     def test_empty_chunk_returns_none(self):
         """Test empty chunk returns None."""
         chunk = {}
-        event = _process_chunk(chunk)
+        event = _process_chunk(chunk, "pt")
         assert event is None
 
 
@@ -566,6 +567,69 @@ class TestRunAgent:
             events.append(event)
             if event.type == "complete":
                 return events
+
+    async def test_forwards_context_to_agent(
+        self,
+        mock_database: MagicMock,
+        mock_user_message: Message,
+        config: ConfigDict,
+        thread_id: str,
+    ):
+        """The run context must reach `agent.astream` — that's how tools and the
+        system-prompt middleware receive the thread's language/user/thread ids."""
+        agent = MagicMock()
+        seen = {}
+
+        async def astream(*args, **kwargs):
+            seen["context"] = kwargs.get("context")
+            yield ("updates", {"model": {"messages": [AIMessage(content="ok")]}})
+
+        agent.astream = astream
+        context = AgentContext(thread_id=thread_id, user_id="u", language="es")
+        queue: asyncio.Queue[StreamEvent] = asyncio.Queue()
+
+        await run_agent(
+            agent=agent,
+            config=config,
+            thread_id=thread_id,
+            user_message=mock_user_message,
+            model_uri=MODEL_URI,
+            context=context,
+            queue=queue,
+        )
+
+        assert seen["context"] is context
+
+    async def test_localizes_error_message_to_context_language(
+        self,
+        mock_database: MagicMock,
+        mock_user_message: Message,
+        config: ConfigDict,
+        thread_id: str,
+    ):
+        """A crash mid-run persists the error message in the thread's language."""
+        agent = MagicMock()
+
+        async def astream(*args, **kwargs):
+            raise RuntimeError("boom")
+            yield  # pragma: no cover — make this an async generator
+
+        agent.astream = astream
+        queue: asyncio.Queue[StreamEvent] = asyncio.Queue()
+
+        await run_agent(
+            agent=agent,
+            config=config,
+            thread_id=thread_id,
+            user_message=mock_user_message,
+            model_uri=MODEL_URI,
+            context=AgentContext(thread_id=thread_id, user_id="u", language="es"),
+            queue=queue,
+        )
+
+        message = mock_database.create_message.call_args[0][0]
+        assert message.status == MessageStatus.ERROR
+        assert message.content == translate(MessageKey.ERROR_UNEXPECTED, "es")
 
     async def test_emits_events_and_persists_success(
         self,
@@ -592,6 +656,9 @@ class TestRunAgent:
             thread_id=thread_id,
             user_message=mock_user_message,
             model_uri=MODEL_URI,
+            context=AgentContext(
+                thread_id="test-thread", user_id="test-user", language="pt"
+            ),
             queue=queue,
         )
 
@@ -656,6 +723,9 @@ class TestRunAgent:
             thread_id=thread_id,
             user_message=mock_user_message,
             model_uri=MODEL_URI,
+            context=AgentContext(
+                thread_id="test-thread", user_id="test-user", language="pt"
+            ),
             queue=queue,
         )
 
@@ -724,6 +794,9 @@ class TestRunAgent:
             thread_id=thread_id,
             user_message=mock_user_message,
             model_uri=MODEL_URI,
+            context=AgentContext(
+                thread_id="test-thread", user_id="test-user", language="pt"
+            ),
             queue=queue,
         )
 
@@ -809,6 +882,9 @@ class TestRunAgent:
             thread_id=thread_id,
             user_message=mock_user_message,
             model_uri=MODEL_URI,
+            context=AgentContext(
+                thread_id="test-thread", user_id="test-user", language="pt"
+            ),
             queue=queue,
         )
         events = await self._drain(queue)
@@ -879,6 +955,9 @@ class TestRunAgent:
             thread_id=thread_id,
             user_message=mock_user_message,
             model_uri=MODEL_URI,
+            context=AgentContext(
+                thread_id="test-thread", user_id="test-user", language="pt"
+            ),
             queue=queue,
         )
 
@@ -914,19 +993,22 @@ class TestRunAgent:
             thread_id=thread_id,
             user_message=mock_user_message,
             model_uri=MODEL_URI,
+            context=AgentContext(
+                thread_id="test-thread", user_id="test-user", language="pt"
+            ),
             queue=queue,
         )
 
         events = await self._drain(queue)
         assert [e.type for e in events] == ["error", "complete"]
-        assert events[0].data.content == t("error_unexpected", "pt")
+        assert events[0].data.content == translate(MessageKey.ERROR_UNEXPECTED, "pt")
         assert events[0].data.error_details == {"reason": "agent_failed"}
 
         mock_database.create_message.assert_called_once()
         message = mock_database.create_message.call_args[0][0]
         assert isinstance(message, MessageCreate)
         assert message.status == MessageStatus.ERROR
-        assert message.content == t("error_unexpected", "pt")
+        assert message.content == translate(MessageKey.ERROR_UNEXPECTED, "pt")
 
     async def test_model_call_limit_persists_with_dedicated_status(
         self,
@@ -953,19 +1035,24 @@ class TestRunAgent:
             thread_id=thread_id,
             user_message=mock_user_message,
             model_uri=MODEL_URI,
+            context=AgentContext(
+                thread_id="test-thread", user_id="test-user", language="pt"
+            ),
             queue=queue,
         )
 
         events = await self._drain(queue)
         assert [e.type for e in events] == ["model_call_limit", "complete"]
-        assert events[0].data.content == t("error_model_call_limit", "pt")
+        assert events[0].data.content == translate(
+            MessageKey.ERROR_MODEL_CALL_LIMIT, "pt"
+        )
         assert events[-1].data.run_id == config["run_id"]
 
         mock_database.create_message.assert_called_once()
         message = mock_database.create_message.call_args[0][0]
         assert isinstance(message, MessageCreate)
         assert message.status == MessageStatus.MODEL_CALL_LIMIT
-        assert message.content == t("error_model_call_limit", "pt")
+        assert message.content == translate(MessageKey.ERROR_MODEL_CALL_LIMIT, "pt")
 
     async def test_complete_still_emitted_when_db_write_fails(
         self,
@@ -1009,6 +1096,9 @@ class TestRunAgent:
             thread_id=thread_id,
             user_message=mock_user_message,
             model_uri=MODEL_URI,
+            context=AgentContext(
+                thread_id="test-thread", user_id="test-user", language="pt"
+            ),
             queue=queue,
         )
 
@@ -1048,6 +1138,9 @@ class TestRunAgent:
                 thread_id=thread_id,
                 user_message=mock_user_message,
                 model_uri=MODEL_URI,
+                context=AgentContext(
+                    thread_id="test-thread", user_id="test-user", language="pt"
+                ),
                 queue=queue,
             )
         )
@@ -1094,6 +1187,9 @@ class TestRunAgent:
                 thread_id=thread_id,
                 user_message=mock_user_message,
                 model_uri=MODEL_URI,
+                context=AgentContext(
+                    thread_id="test-thread", user_id="test-user", language="pt"
+                ),
                 queue=queue,
             )
         )
@@ -1112,7 +1208,7 @@ class TestRunAgent:
         message = mock_database.create_message.call_args[0][0]
         assert isinstance(message, MessageCreate)
         assert message.status == MessageStatus.INTERRUPTED
-        assert message.content == t("error_interrupted", "pt")
+        assert message.content == translate(MessageKey.ERROR_INTERRUPTED, "pt")
 
     async def test_cancellation_after_final_answer_preserves_success(
         self,
@@ -1147,6 +1243,9 @@ class TestRunAgent:
                 thread_id=thread_id,
                 user_message=mock_user_message,
                 model_uri=MODEL_URI,
+                context=AgentContext(
+                    thread_id="test-thread", user_id="test-user", language="pt"
+                ),
                 queue=queue,
             )
         )

--- a/tests/app/api/streaming/test_data_sources.py
+++ b/tests/app/api/streaming/test_data_sources.py
@@ -27,6 +27,49 @@ class TestResolveTableName:
         node = {"namePt": table_name, "dataset": {"namePt": dataset_name}}
         return {"data": {"allTable": {"edges": [{"node": node}]}}}
 
+    @staticmethod
+    def _bilingual_response(pt: tuple[str, str], en: tuple[str, str]):
+        node = {
+            "namePt": pt[1],
+            "nameEn": en[1],
+            "dataset": {"namePt": pt[0], "nameEn": en[0]},
+        }
+        return {"data": {"allTable": {"edges": [{"node": node}]}}}
+
+    @respx.mock
+    async def test_resolves_in_requested_language(self):
+        """The resolved name uses the requested language's fields."""
+        respx.post(_GRAPHQL_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json=self._bilingual_response(
+                    pt=("Diretórios", "Município"), en=("Directories", "Municipality")
+                ),
+            )
+        )
+
+        assert await _resolve_table_name("tb1", "en") == "Directories — Municipality"
+
+    @respx.mock
+    async def test_cache_is_keyed_per_language(self):
+        """The same table resolves independently per language — the cache must not collide."""
+        route = respx.post(_GRAPHQL_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json=self._bilingual_response(
+                    pt=("Diretórios", "Município"), en=("Directories", "Municipality")
+                ),
+            )
+        )
+
+        pt_name = await _resolve_table_name("tb1", "pt")
+        en_name = await _resolve_table_name("tb1", "en")
+
+        assert pt_name == "Diretórios — Município"
+        assert en_name == "Directories — Municipality"
+        # Two distinct cache keys => two lookups (not one shared, wrong-language entry).
+        assert route.call_count == 2
+
     @respx.mock
     async def test_builds_dataset_dash_table_name(self):
         """A resolved table yields '{dataset_name} — {table_name}'."""
@@ -36,7 +79,10 @@ class TestResolveTableName:
             )
         )
 
-        assert await _resolve_table_name("tb1", "pt") == "Diretórios Brasileiros — Município"
+        assert (
+            await _resolve_table_name("tb1", "pt")
+            == "Diretórios Brasileiros — Município"
+        )
 
     @respx.mock
     async def test_caches_successful_resolution(self):
@@ -61,7 +107,9 @@ class TestResolveTableName:
         )
 
         assert await _resolve_table_name("missing", "pt") is None
-        assert ("pt", "missing") not in _TABLE_NAME_CACHE
+        # Cache is keyed (table_id, language); assert the real key
+        # so this actually verifies that None results are not cached.
+        assert ("missing", "pt") not in _TABLE_NAME_CACHE
 
     @respx.mock
     async def test_returns_none_on_missing_dataset_name(self):
@@ -124,7 +172,7 @@ class TestResolveDataSourceNames:
             ]
         }
 
-        await resolve_data_source_names(structured)
+        await resolve_data_source_names(structured, "pt")
 
         assert structured["data_sources"] == [
             {"dataset_id": "ds1", "table_id": "tb1", "name": "Conjunto - tb1"},
@@ -146,7 +194,7 @@ class TestResolveDataSourceNames:
             ]
         }
 
-        await resolve_data_source_names(structured)
+        await resolve_data_source_names(structured, "pt")
 
         assert structured["data_sources"] == [
             {"dataset_id": "ds1", "table_id": "tb1", "name": "model fallback"}
@@ -162,8 +210,8 @@ class TestResolveDataSourceNames:
             "app.api.streaming.data_sources._resolve_table_name", resolve_name
         )
 
-        await resolve_data_source_names({"data_sources": None})
-        await resolve_data_source_names({"data_sources": []})
-        await resolve_data_source_names({})
+        await resolve_data_source_names({"data_sources": None}, "pt")
+        await resolve_data_source_names({"data_sources": []}, "pt")
+        await resolve_data_source_names({}, "pt")
 
         resolve_name.assert_not_awaited()

--- a/tests/app/db/test_models.py
+++ b/tests/app/db/test_models.py
@@ -1,0 +1,23 @@
+import pytest
+
+from app.db.models import ThreadPayload
+
+
+class TestThreadLanguageNormalization:
+    """`ThreadPayload.language` is the single normalization boundary: a `before` validator
+    coerces raw input to a valid LanguageCode so everything downstream can trust it."""
+
+    def test_normalizes_case(self):
+        assert ThreadPayload(title="t", language="EN").language == "en"
+
+    @pytest.mark.parametrize("value", ["fr", "de", "unknown", ""])
+    def test_coerces_unsupported_to_default_without_raising(self, value: str):
+        # The Literal field would reject these, but the `before` validator coerces first —
+        # this guards against someone dropping mode="before" (which would 422 real requests).
+        assert ThreadPayload(title="t", language=value).language == "pt"
+
+    def test_explicit_null_falls_back_to_default(self):
+        assert ThreadPayload(title="t", language=None).language == "pt"
+
+    def test_omitted_uses_default(self):
+        assert ThreadPayload(title="t").language == "pt"

--- a/tests/app/test_i18n.py
+++ b/tests/app/test_i18n.py
@@ -1,12 +1,15 @@
+from typing import get_args
+
 import pytest
 
 from app.i18n import (
     DEFAULT_LANGUAGE,
-    LANGUAGES,
-    _MESSAGES,
+    LanguageCode,
+    MessageKey,
     language_directive,
+    localized_field,
     normalize_language,
-    t,
+    translate,
 )
 
 
@@ -25,17 +28,24 @@ class TestNormalizeLanguage:
 
 
 class TestTranslate:
-    def test_every_key_covers_every_language(self):
-        for key, translations in _MESSAGES.items():
-            assert set(translations) == set(LANGUAGES), f"'{key}' is missing a language"
-            assert all(v.strip() for v in translations.values()), f"'{key}' has empty text"
+    def test_every_key_resolves_in_every_language(self):
+        # Guards against a key that's missing a language (translate would KeyError)
+        # or has empty text — the common failure when adding a message or a locale.
+        for key in MessageKey:
+            for language in get_args(LanguageCode):
+                text = translate(key, language)
+                assert text and text.strip(), f"{key} / {language} is empty"
 
     def test_returns_language_specific_text(self):
-        assert t("results_expired", "en") != t("results_expired", "pt")
-        assert t("results_expired", "en") != t("results_expired", "es")
+        expired = MessageKey.RESULTS_EXPIRED
+        assert translate(expired, "en") != translate(expired, "pt")
+        assert translate(expired, "en") != translate(expired, "es")
 
-    def test_unsupported_language_falls_back_to_default(self):
-        assert t("error_unexpected", "fr") == t("error_unexpected", DEFAULT_LANGUAGE)
+    def test_does_not_fall_back_on_unsupported_language(self):
+        # Normalization is the caller's responsibility (see normalize_language);
+        # translate trusts it receives a valid LanguageCode.
+        with pytest.raises(KeyError):
+            translate(MessageKey.ERROR_UNEXPECTED, "fr")
 
 
 class TestLanguageDirective:
@@ -46,5 +56,30 @@ class TestLanguageDirective:
     def test_names_the_target_language(self, language: str, expected_name: str):
         assert expected_name in language_directive(language)
 
-    def test_unsupported_language_falls_back_to_default_name(self):
-        assert "Portuguese" in language_directive("fr")
+    def test_does_not_fall_back_on_unsupported_language(self):
+        # language_directive trusts it receives a valid LanguageCode.
+        with pytest.raises(KeyError):
+            language_directive("fr")
+
+
+class TestLocalizedField:
+    """The metadata-localization primitive: pick `{field}{Suffix}`, fall back to pt."""
+
+    def test_returns_requested_language_value(self):
+        node = {"namePt": "Município", "nameEn": "Municipality", "nameEs": "Municipio"}
+        assert localized_field(node, "name", "en") == "Municipality"
+        assert localized_field(node, "name", "es") == "Municipio"
+        assert localized_field(node, "name", "pt") == "Município"
+
+    def test_falls_back_to_pt_when_requested_language_missing(self):
+        # Partial translation coverage: only pt is populated for this node.
+        node = {"namePt": "Município"}
+        assert localized_field(node, "name", "en") == "Município"
+
+    def test_falls_back_to_pt_when_requested_language_is_empty(self):
+        # An empty localized value is treated as "not translated" (the `or` branch).
+        node = {"namePt": "Município", "nameEn": ""}
+        assert localized_field(node, "name", "en") == "Município"
+
+    def test_returns_none_when_neither_language_present(self):
+        assert localized_field({}, "name", "en") is None


### PR DESCRIPTION
Refactor of the already-merged thread-language feature (pt/en/es).

### Main changes
- **Language steering moved to a middleware.** A `dynamic_prompt` middleware renders the system prompt per run, filling `{current_date}` and a new `{language_directive}` placeholder. This removes the old approach of prepending the directive to the user message — so it no longer leaks into the persisted `Message` or the checkpoint history, and the date now reflects request time rather than server-start time.

- **`config["configurable"]` → LangChain v1 `context`.** Introduced `AgentContext` (as `context_schema`); tools and the middleware now read `runtime.context` instead of `config["configurable"]`. `thread_id` stays in `configurable` only because the langgraph checkpointer keys on it.

- **Language normalized once, at the boundary.** `ThreadPayload.language` (a `before` validator) is the single normalization point, typed `LanguageCode`; downstream helpers trust a valid code instead of each re-applying a fallback. Renamed `t()` → `translate()` with a `MessageKey` enum, and made the `app.i18n` internals private.

- **Trace attributes via `config["metadata"]`.** `thread_id`/`user_id`/`language` are declared explicitly as metadata so LangSmith surfaces them as Attributes (the context move had dropped `user_id` from traces; `language` is newly filterable).

- **Small fixes.** `_authorize_message` returns the thread it already fetched (drops a duplicate query in the export endpoint); `_fetch_usage_guide` falls back through `DEFAULT_LANGUAGE` instead of a hardcoded `"pt"`.

### Tests
Expanded coverage for behavior that was previously untested: `localized_field` pt-fallback, non-pt metadata localization in the tools, the usage-guide language fallback, per-`(table_id, language)` name-cache keying, the `ThreadPayload` normalization boundary, `run_agent` forwarding context to the agent, and the trace metadata. Full suite green.

### Notes
GraphQL queries and the DB migration are unchanged from staging (comment-only diffs), so no new backend/schema dependency beyond what's already live.